### PR TITLE
Fix blackbox sampling

### DIFF
--- a/examples/configs/polygraph_eval_babiqa.yaml
+++ b/examples/configs/polygraph_eval_babiqa.yaml
@@ -1,6 +1,6 @@
 hydra:
   run:
-    dir: ${cache_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${cache_path}/${task}/${dataset_name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
@@ -13,6 +13,7 @@ estimator_kwargs: {}
 
 task: qa
 
+dataset_name: babi_qa
 dataset: [facebook/babi_qa, en-10k-qa1]
 text_column: text
 label_column: answer

--- a/examples/configs/polygraph_eval_coqa.yaml
+++ b/examples/configs/polygraph_eval_coqa.yaml
@@ -1,8 +1,9 @@
-save_path: './workdir/output'
-
 hydra:
   run:
-    dir: ${save_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${cache_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
 
 device: cpu
 
@@ -56,5 +57,4 @@ batch_size: 2
 
 seed:
     - 1
-
-cache_path: ./workdir
+    

--- a/examples/configs/polygraph_eval_wmt14_ende.yaml
+++ b/examples/configs/polygraph_eval_wmt14_ende.yaml
@@ -1,8 +1,9 @@
-save_path: './workdir/output'
-
 hydra:
   run:
-    dir: ${save_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${cache_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
 
 device: cpu
 
@@ -56,5 +57,4 @@ batch_size: 2
 
 seed:
     - 1
-
-cache_path: ./workdir
+    

--- a/examples/configs/polygraph_eval_wmt14_enfr.yaml
+++ b/examples/configs/polygraph_eval_wmt14_enfr.yaml
@@ -1,8 +1,9 @@
-save_path: './workdir/output'
-
 hydra:
   run:
-    dir: ${save_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${cache_path}/${task}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
 
 device: cpu
 
@@ -56,5 +57,4 @@ batch_size: 2
 
 seed:
     - 1
-
-cache_path: ./workdir
+    

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -24,7 +24,7 @@ class BlackboxSamplingGenerationCalculator(StatCalculator):
                     top_p=model.parameters.topp,
                     presence_penalty=model.parameters.presence_penalty,
                     repetition_penalty=model.parameters.repetition_penalty,
-                    top_k=model.parameters.topk,
+                    top_k=model.parameters.topk if model.parameters.topk > 1 else 50,
                     n=self.samples_n)
         else:
             samples = [[] for _ in range(len(texts))]
@@ -37,11 +37,11 @@ class BlackboxSamplingGenerationCalculator(StatCalculator):
                     temperature=model.parameters.temperature,
                     top_p=model.parameters.topp,
                     repetition_penalty=model.parameters.repetition_penalty,
-                    top_k=model.parameters.topk,
+                    top_k=model.parameters.topk if model.parameters.topk > 1 else 50,
                     num_return_sequences=self.samples_n)
             for i in range(len(texts)):
                 for j in range(self.samples_n):
-                    samples[i].append(out[i + j])
+                    samples[i].append(out[i*self.samples_n + j])
         
         return {
             'blackbox_sample_texts': samples,

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -141,7 +141,14 @@ class WhiteboxModel(Model):
         args['return_dict_in_generate'] = True
         batch: Dict[str, torch.Tensor] = self.tokenize(input_texts)
         batch = {k: v.to(self.device()) for k, v in batch.items()}
-        texts = [self.tokenizer.decode(x) for x in self.model.generate(**batch, **args).sequences.cpu()]
+        sequences = self.model.generate(**batch, **args).sequences.cpu()
+        input_len = batch['input_ids'].shape[1]
+        texts = []
+        for seq in sequences:
+            if self.model_type == "CausalLM":
+                texts.append(self.tokenizer.decode(seq[input_len:]))
+            else:
+                texts.append(self.tokenizer.decode(seq[1:]))                  
         return texts
 
     def __call__(self, **args):


### PR DESCRIPTION
- Немного обновил конфиги так, чтобы везде был правильно указан `save_path`
- Исправил семплирование для blackbox методов
    1. в семплированных ответах `blackbox_sample_texts` и в `blackbox_greedy_texts` сохранялся промпт, из-за чего методы использовали промпт+ответ для подсчета скоров
    2.  для `blackbox_sample_texts` неправильно группировались ответы
    3.  параметр `top_k` для `blackbox_sample_texts` у нас использовался по умолчанию равный 1, из-за чего получали всегда одинаковые ответы
    
Стоит заметить, что большая часть экспериментов отработала корректно, т.к. в бенчмарке, если у нас есть `sample_texts` (а он считается корректно), то он копируется в `blackbox_sample_texts` и отдельно для blackbox не запускается. А `sample_texts` у нас считается во многих методах, поэтому ошибка была только если запускать blackbox  методы отдельно. 

Но при этом, из-за такой ошибки, вероятно, в demo интерфейсе lexical similarity для llama работает хуже, чем для gpt, потому что считает `blackbox_sample_texts`