### PR TITLE
Correct type of p(True) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ estimate_uncertainty(model, ue_method, input_text=input_text)
 | Robust density estimation (RDE) (Yoo et al., 2022)                  | White-box   | Density-based       | Low     | Low    |         Yes         |
 | Relative Mahalanobis distance (RMD) (Ren et al., 2023)              | White-box   | Density-based       | Low     | Low    |         Yes         |
 | Hybrid Uncertainty Quantification (HUQ) (Vazhentsev et al., 2023a)  | White-box   | Density-based       | Low     | Low    |         Yes         |
-| p(True) (Kadavath et al., 2022)                                     | White-box   | Reflexive           | Medium  | Low    |         No          |
+| p(True) (Kadavath et al., 2022)                                     | Black-box   | Reflexive           | Medium  | Low    |         No          |
 | Number of semantic sets (NumSets) (Kuhn et al., 2023)               | Black-box   | Meaning Diversity   | High    | Low    |         No          |
 | Sum of eigenvalues of the graph Laplacian (EigV) (Lin et al., 2023) | Black-box   | Meaning Diversity   | High    | Low    |         No          |
 | Degree matrix (Deg) (Lin et al., 2023)                              | Black-box   | Meaning Diversity   | High    | Low    |         No          |


### PR DESCRIPTION
As I got from the presentation on AIST'2023 Conference, p(True) method is actually a black box method since it doesn't require any knowledge about probabilities distribution or access internal model embeddings.