### PR TITLE
Ood detection optimized

### DIFF
--- a/examples/configs/polygraph_eval_ood.yaml
+++ b/examples/configs/polygraph_eval_ood.yaml
@@ -1,0 +1,18 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${id_dataset}_${ood_dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+device: "cpu"
+
+task: ood
+
+id_dataset: aeslc
+ood_dataset: aeslc_corrupted
+
+model: databricks/dolly-v2-3b
+
+id_manager_path:
+ood_manager_path: 

--- a/examples/corrupt_dataset.py
+++ b/examples/corrupt_dataset.py
@@ -1,0 +1,60 @@
+import os
+import hydra
+import pandas as pd
+from pathlib import Path
+
+from numpy.random import Generator, default_rng
+from transformers import AutoTokenizer
+from lm_polygraph.utils.dataset import Dataset
+
+import logging
+
+log = logging.getLogger()
+
+hydra_config = Path(os.environ["HYDRA_CONFIG"])
+
+def corrupt(text: str, tokenizer, gen: Generator) -> str:
+    assert tokenizer is not None, "Tokenizer is not defined"
+    tokens = tokenizer.encode(text)
+    tokens = tokens[1:-1]  # Remove SEP and CLS tokens
+    gen.shuffle(tokens)
+    return tokenizer.decode(tokens, skip_special_tokens=True)
+
+
+@hydra.main(
+    version_base=None,
+    config_path=str(hydra_config.parent),
+    config_name=str(hydra_config.name),
+)
+def main(args):
+    save_path = os.getcwd()
+    log.info(f"Main directory: {save_path}")
+    os.chdir(hydra.utils.get_original_cwd())
+
+    save_path = args.save_path if "save_path" in args else save_path
+
+    seed = args.seed if isinstance(args.seed, int) else args.seed[0]
+    log.info(f"Loading dataset {args.dataset}...")
+    dataset = Dataset.load(
+        args.dataset,
+        args.text_column,
+        args.label_column,
+        batch_size=args.batch_size,
+        prompt=args.prompt,
+        split=args.eval_split,
+        load_from_disk=args.load_from_disk,
+    )
+
+    if args.subsample_eval_dataset != -1:
+        dataset.subsample(args.subsample_eval_dataset, seed=seed)
+        
+    random_gen = default_rng(seed=seed)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    
+    corrupted_text = [corrupt(x, tokenizer, random_gen) for x in dataset.x]
+    
+    df = pd.DataFrame({f"{args.text_column}_corrupted": corrupted_text, args.text_column: dataset.x, args.label_column: dataset.y})
+    df.to_csv(save_path + f"/{args.dataset}_corrupted.csv", index=False)
+    
+if __name__ == "__main__":
+    main()

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -218,13 +218,13 @@ def main(args):
 def get_density_based_ue_methods(args, model_type):
     estimators = []
     if args.use_density_based_ue:
-        if not getattr(args, 'parameters_path', False):
+        if getattr(args, 'parameters_path', False):
+            parameters_path = args.parameters_path
+        else:
             dataset_name = args.dataset if isinstance(args.dataset, str) else '_'.join(args.dataset)
             dataset_name = dataset_name.split("/")[-1].split(".")[0]
             model_name = args.model.split("/")[-1]
             parameters_path = f"{args.cache_path}/density_stats/{dataset_name}/{model_name}"
-        else:
-            parameters_path = args.parameters_path
         
         if model_type == "Seq2SeqLM":
             estimators += [

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -31,13 +31,6 @@ from lm_polygraph.ue_metrics import (
     RiskCoverageCurveAUC,
 )
 
-DENSITY_BASED_ESTIMATORS = [
-    "MahalanobisDistanceSeq",
-    "RelativeMahalanobisDistanceSeq",
-    "RDESeq",
-    "PPLMDSeq",
-]
-
 hydra_config = Path(os.environ["HYDRA_CONFIG"])
 
 
@@ -125,9 +118,10 @@ def main(args):
 
         estimators = []
         estimators += get_ue_methods(args, model)
-        estimators += get_density_based_ue_methods(args, model.model_type)
+        density_based_ue_methods = get_density_based_ue_methods(args, model.model_type)
+        estimators += density_based_ue_methods
 
-        if any([str(estimator).split('_')[0] in DENSITY_BASED_ESTIMATORS for estimator in estimators]):
+        if any([not getattr(method, "is_fitted", False) for method in density_based_ue_methods]):
             if (args.train_dataset is not None) and (
                     args.train_dataset != args.dataset
             ):
@@ -183,7 +177,6 @@ def main(args):
         else:
             train_dataset = None
             background_train_dataset = None
-            density_based_ue = []
 
         if args.subsample_eval_dataset != -1:
             dataset.subsample(args.subsample_eval_dataset, seed=seed)
@@ -225,11 +218,14 @@ def main(args):
 def get_density_based_ue_methods(args, model_type):
     estimators = []
     if args.use_density_based_ue:
-        dataset_name = args.dataset if isinstance(args.dataset, str) else '_'.join(args.dataset)
-        dataset_name = dataset_name.split("/")[-1].split(".")[0]
-        model_name = args.model.split("/")[-1]
-        parameters_path = f"{args.cache_path}/density_stats/{dataset_name}/{model_name}"
-
+        if not getattr(args, 'parameters_path', False):
+            dataset_name = args.dataset if isinstance(args.dataset, str) else '_'.join(args.dataset)
+            dataset_name = dataset_name.split("/")[-1].split(".")[0]
+            model_name = args.model.split("/")[-1]
+            parameters_path = f"{args.cache_path}/density_stats/{dataset_name}/{model_name}"
+        else:
+            parameters_path = args.parameters_path
+        
         if model_type == "Seq2SeqLM":
             estimators += [
                 MahalanobisDistanceSeq("encoder", parameters_path=parameters_path),

--- a/scripts/polygraph_eval_ood
+++ b/scripts/polygraph_eval_ood
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import hydra
+import importlib
+import os
+import argparse
+from pathlib import Path
+import json
+
+import logging
+
+log = logging.getLogger()
+
+from lm_polygraph.utils.manager import UEManager
+from lm_polygraph.utils.ood_detection import calculate_ood_from_mans
+from lm_polygraph.ue_metrics import ROCAUC
+
+hydra_config = Path(os.environ["HYDRA_CONFIG"])
+
+@hydra.main(
+    version_base=None,
+    config_path=str(hydra_config.parent),
+    config_name=str(hydra_config.name),
+)
+def main(args):
+    save_path = os.getcwd()
+    log.info(f"Main directory: {save_path}")
+    os.chdir(hydra.utils.get_original_cwd())
+
+    save_path = args.save_path if "save_path" in args else save_path
+    
+    man_id = UEManager.load(args.id_results_path)
+    man_ood = UEManager.load(args.ood_results_path)
+    
+    ood_metrics = [ROCAUC()]
+    ood_results = calculate_ood_from_mans(man_id, man_ood, ood_metrics)
+    
+    with open(Path(save_path) / "ood_inference.json", "w") as res_file:
+        json.dump(ood_results, res_file)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/polygraph_eval_ood
+++ b/scripts/polygraph_eval_ood
@@ -29,8 +29,8 @@ def main(args):
 
     save_path = args.save_path if "save_path" in args else save_path
     
-    man_id = UEManager.load(args.id_results_path)
-    man_ood = UEManager.load(args.ood_results_path)
+    man_id = UEManager.load(args.id_manager_path)
+    man_ood = UEManager.load(args.ood_manager_path)
     
     ood_metrics = [ROCAUC()]
     ood_results = calculate_ood_from_mans(man_id, man_ood, ood_metrics)

--- a/src/lm_polygraph/estimators/mahalanobis_distance.py
+++ b/src/lm_polygraph/estimators/mahalanobis_distance.py
@@ -137,6 +137,7 @@ class MahalanobisDistanceSeq(Estimator):
             )
             if self.parameters_path is not None:
                 torch.save(self.sigma_inv, f"{self.full_path}/sigma_inv.pt")
+            self.is_fitted = True
         
         if torch.cuda.is_available():
             if not self.centroid.is_cuda:

--- a/src/lm_polygraph/estimators/mahalanobis_distance.py
+++ b/src/lm_polygraph/estimators/mahalanobis_distance.py
@@ -100,6 +100,7 @@ class MahalanobisDistanceSeq(Estimator):
         self.normalize = normalize
         self.min = 1e+100
         self.max = -1e+100
+        self.is_fitted = False
         
         if self.parameters_path is not None:
             self.full_path = f"{self.parameters_path}/md_{self.embeddings_type}" 
@@ -110,6 +111,7 @@ class MahalanobisDistanceSeq(Estimator):
                 self.sigma_inv = torch.load(f"{self.full_path}/sigma_inv.pt")
                 self.max = torch.load(f"{self.full_path}/max.pt")
                 self.min = torch.load(f"{self.full_path}/min.pt")
+                self.is_fitted = True
             
 
     def __str__(self):
@@ -121,14 +123,14 @@ class MahalanobisDistanceSeq(Estimator):
         embeddings = create_cuda_tensor_from_numpy(stats[f'embeddings_{self.embeddings_type}'])
             
         # compute centroids if not given     
-        if self.centroid is None:
+        if not self.is_fitted:
             train_embeddings = create_cuda_tensor_from_numpy(stats[f'train_embeddings_{self.embeddings_type}'])            
             self.centroid = train_embeddings.mean(axis=0)
             if self.parameters_path is not None:
                 torch.save(self.centroid, f"{self.full_path}/centroid.pt")
         
         # compute inverse covariance matrix if not given
-        if self.sigma_inv is None:
+        if not self.is_fitted:
             train_embeddings = create_cuda_tensor_from_numpy(stats[f'train_embeddings_{self.embeddings_type}'])  
             self.sigma_inv, _ = compute_inv_covariance(
                 self.centroid.unsqueeze(0), train_embeddings

--- a/src/lm_polygraph/estimators/ppl_md.py
+++ b/src/lm_polygraph/estimators/ppl_md.py
@@ -38,6 +38,7 @@ class PPLMDSeq(Estimator):
         
         self.train_ppl = None
         self.train_md = None
+        self.is_fitted = False
         
         self.PPL = Perplexity()
         if self.md_type == "MD":
@@ -56,6 +57,7 @@ class PPLMDSeq(Estimator):
             if os.path.exists(f"{self.full_path}/train_md.npy"):
                 self.train_ppl = load_array(f"{self.full_path}/train_ppl.npy")
                 self.train_md = load_array(f"{self.full_path}/train_md.npy")
+                self.is_fitted = True
 
     def __str__(self):
         return f'PPL{self.md_type}Seq_{self.embeddings_type}'
@@ -64,13 +66,13 @@ class PPLMDSeq(Estimator):
         ppl = self.PPL(stats)
         md = self.MD(stats)
         
-        if self.train_ppl is None:
+        if not self.is_fitted:
             copy_stats = copy.deepcopy(stats)
             copy_stats['greedy_log_likelihoods'] = copy_stats['train_greedy_log_likelihoods']
             self.train_ppl = self.PPL(copy_stats)
             if self.parameters_path is not None:
                 save_array(self.train_ppl, f"{self.full_path}/train_ppl.npy")
-        if self.train_md is None:
+        if not self.is_fitted:
             train_embeds, val_embeds = train_test_split(stats[f'train_embeddings_{self.embeddings_type}'], test_size=0.3, random_state=42)
             copy_stats = copy.deepcopy(stats)
             copy_stats[f'train_embeddings_{self.embeddings_type}'] = train_embeds

--- a/src/lm_polygraph/estimators/ppl_md.py
+++ b/src/lm_polygraph/estimators/ppl_md.py
@@ -80,6 +80,7 @@ class PPLMDSeq(Estimator):
             self.train_md = self.MD_val(copy_stats)
             if self.parameters_path is not None:
                 save_array(self.train_md, f"{self.full_path}/train_md.npy")
+            self.is_fitted = True
             
         ppl_rank = rank(ppl, self.train_ppl)
         md_rank = rank(md, self.train_md)

--- a/src/lm_polygraph/estimators/rde.py
+++ b/src/lm_polygraph/estimators/rde.py
@@ -95,6 +95,7 @@ class RDESeq(Estimator):
             self.MCD = MCD_covariance(X_pca_train)
             if self.parameters_path is not None:
                 self.save_mcd()
+            self.is_fitted = True
         
         # transform test data based on pca
         X_pca_test = self.pca.transform(embeddings)

--- a/src/lm_polygraph/estimators/rde.py
+++ b/src/lm_polygraph/estimators/rde.py
@@ -61,6 +61,7 @@ class RDESeq(Estimator):
         self.normalize = normalize
         self.min = 1e+100
         self.max = -1e+100
+        self.is_fitted = False
         
         if self.parameters_path is not None:
             self.full_path = f"{self.parameters_path}/rde_{self.embeddings_type}" 
@@ -70,6 +71,7 @@ class RDESeq(Estimator):
                 self.MCD = self.load_mcd()
                 self.max = load_array(f"{self.full_path}/max.npy")
                 self.min = load_array(f"{self.full_path}/min.npy")
+                self.is_fitted = True
             
 
     def __str__(self):
@@ -82,14 +84,14 @@ class RDESeq(Estimator):
 
 
         # define PCA with rbf kernel and n_components equal 100
-        if self.pca is None:
+        if not self.is_fitted:
             self.pca = KernelPCA(n_components=100, kernel="rbf", random_state=42, gamma=None)
             X_pca_train = self.pca.fit_transform(stats[f'train_embeddings_{self.embeddings_type}'])            
             if self.parameters_path is not None:
                 self.save_pca()
                 
         # define mean covariance distance
-        if self.MCD is None:
+        if not self.is_fitted:
             self.MCD = MCD_covariance(X_pca_train)
             if self.parameters_path is not None:
                 self.save_mcd()

--- a/src/lm_polygraph/estimators/relative_mahalanobis_distance.py
+++ b/src/lm_polygraph/estimators/relative_mahalanobis_distance.py
@@ -35,6 +35,7 @@ class RelativeMahalanobisDistanceSeq(Estimator):
         self.min = 1e+100
         self.max = -1e+100
         self.MD = MahalanobisDistanceSeq(embeddings_type, parameters_path, normalize=False)
+        self.is_fitted = False
         
         if self.parameters_path is not None:
             self.full_path = f"{self.parameters_path}/rmd_{self.embeddings_type}" 
@@ -44,6 +45,8 @@ class RelativeMahalanobisDistanceSeq(Estimator):
                 self.sigma_inv_0 = torch.load(f"{self.full_path}/sigma_inv_0.pt")
                 self.max = load_array(f"{self.full_path}/max_0.npy")
                 self.min = load_array(f"{self.full_path}/min_0.npy")
+                self.is_fitted = True
+                
 
     def __str__(self):
         return f'RelativeMahalanobisDistanceSeq_{self.embeddings_type}'
@@ -57,13 +60,13 @@ class RelativeMahalanobisDistanceSeq(Estimator):
         # we have to compute average train centroid and inverse cavariance matrix
         # to obtain MD_0
 
-        if self.centroid_0 is None:
+        if not self.is_fitted:
             background_train_embeddings = create_cuda_tensor_from_numpy(stats[f'background_train_embeddings_{self.embeddings_type}'])  
             self.centroid_0 = background_train_embeddings.mean(axis=0)
             if self.parameters_path is not None:
                 torch.save(self.centroid_0, f"{self.full_path}/centroid_0.pt")
                 
-        if self.sigma_inv_0 is None:
+        if not self.is_fitted:
             background_train_embeddings = create_cuda_tensor_from_numpy(stats[f'background_train_embeddings_{self.embeddings_type}'])  
             self.sigma_inv_0, _ = compute_inv_covariance(
                 self.centroid_0.unsqueeze(0), background_train_embeddings

--- a/src/lm_polygraph/estimators/relative_mahalanobis_distance.py
+++ b/src/lm_polygraph/estimators/relative_mahalanobis_distance.py
@@ -73,7 +73,7 @@ class RelativeMahalanobisDistanceSeq(Estimator):
             )
             if self.parameters_path is not None:
                 torch.save(self.sigma_inv_0, f"{self.full_path}/sigma_inv_0.pt")
-                
+            self.is_fitted = True
                 
         if torch.cuda.is_available():
             if not self.centroid_0.is_cuda:

--- a/src/lm_polygraph/ue_metrics/__init__.py
+++ b/src/lm_polygraph/ue_metrics/__init__.py
@@ -3,3 +3,4 @@ from .rev_pairs_prop import ReversedPairsProportion
 from .risk_cov_curve import RiskCoverageCurveAUC
 from .spearmanr import SpearmanRankCorrelation
 from .kendalltau import KendallTauCorrelation
+from .roc_auc import ROCAUC

--- a/src/lm_polygraph/ue_metrics/roc_auc.py
+++ b/src/lm_polygraph/ue_metrics/roc_auc.py
@@ -1,0 +1,24 @@
+import numpy as np
+from sklearn.metrics import roc_auc_score
+
+from typing import List
+
+from .ue_metric import UEMetric
+
+
+class ROCAUC(UEMetric):
+    is_ood_metric = True
+    def __str__(self):
+        return 'roc-auc'
+    
+    def preprocess_inf(self, x, array):
+        if not np.isinf(x):
+            return x
+        elif x > 0:
+            return array.max()+1
+        else:
+            return array.min()-1
+
+    def __call__(self, estimator: List[float], target: List[int]) -> float:
+        estimator = [self.preprocess_inf(x, estimator) for x in estimator]
+        return roc_auc_score(target, estimator)

--- a/src/lm_polygraph/utils/dataset.py
+++ b/src/lm_polygraph/utils/dataset.py
@@ -95,7 +95,7 @@ class Dataset:
         self.select(indices)
 
     @staticmethod
-    def from_csv(csv_path: str, x_column: str, y_column: str, batch_size: int, **kwargs):
+    def from_csv(csv_path: str, x_column: str, y_column: str, batch_size: int, prompt: str = "", **kwargs):
         """
         Creates the dataset from .CSV table.
 
@@ -108,6 +108,10 @@ class Dataset:
         csv = pd.read_csv(csv_path)
         x = csv[x_column].tolist()
         y = csv[y_column].tolist()
+        
+        if len(prompt):
+            x = [prompt.format(text=text) for text in x]
+                        
         return Dataset(x, y, batch_size)
 
     @staticmethod

--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -323,6 +323,10 @@ class UEManager:
                 batch_stats['target_tokens'] = target_tokens
 
             batch_stats['deberta_batch_size'] = self.deberta_batch_size
+            for stat in train_stats.keys():
+                batch_stats[stat] = train_stats[stat]
+            for stat in background_train_stats.keys():
+                batch_stats[stat] = background_train_stats[stat]
 
             batch_stats = self.calculate(batch_stats,
                                          self.stat_calculators,

--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -323,10 +323,13 @@ class UEManager:
                 batch_stats['target_tokens'] = target_tokens
 
             batch_stats['deberta_batch_size'] = self.deberta_batch_size
-            for stat in train_stats.keys():
-                batch_stats[stat] = train_stats[stat]
-            for stat in background_train_stats.keys():
-                batch_stats[stat] = background_train_stats[stat]
+            train_stats_keys = list(train_stats.keys())
+            for stat in train_stats_keys:
+                batch_stats[stat] = train_stats.pop(stat)
+            
+            background_train_stats_keys = list(background_train_stats.keys())
+            for stat in background_train_stats_keys:
+                batch_stats[stat] = background_train_stats.pop(stat)
 
             batch_stats = self.calculate(batch_stats,
                                          self.stat_calculators,

--- a/src/lm_polygraph/utils/ood_detection.py
+++ b/src/lm_polygraph/utils/ood_detection.py
@@ -8,10 +8,11 @@ def calculate_ood_from_mans(manager_id, manager_ood, ood_metrics):
         
     results = {}
     for ood_metric in ood_metrics:
+        results[str(ood_metric)] = {}
         for ue_method in ue_methods:
             ue_id = manager_id.estimations[("sequence", ue_method)]
             ue_ood = manager_ood.estimations[("sequence", ue_method)]
             ood_labels = [0]*len(ue_id) + [1]*len(ue_ood)
             ue = np.concatenate([ue_id, ue_ood])
-            results[(ood_metric, ue_method)] = ood_metric(ue, ood_labels)
+            results[str(ood_metric)][ue_method] = ood_metric(ue, ood_labels)
     return results

--- a/src/lm_polygraph/utils/ood_detection.py
+++ b/src/lm_polygraph/utils/ood_detection.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+def calculate_ood_from_mans(manager_id, manager_ood, ood_metrics):
+    
+    ue_methods_id = set([m[1] for m in manager_id.estimations.keys()])
+    ue_methods_ood = set([m[1] for m in manager_ood.estimations.keys()])
+    ue_methods = ue_methods_id.intersection(ue_methods_ood)
+        
+    results = {}
+    for ood_metric in ood_metrics:
+        for ue_method in ue_methods:
+            ue_id = manager_id.estimations[("sequence", ue_method)]
+            ue_ood = manager_ood.estimations[("sequence", ue_method)]
+            ood_labels = [0]*len(ue_id) + [1]*len(ue_ood)
+            ue = np.concatenate([ue_id, ue_ood])
+            results[(ood_metric, ue_method)] = ood_metric(ue, ood_labels)
+    return results


### PR DESCRIPTION
Example of usage:

Corrupt dataset:
CUDA_VISIBLE_DEVICES=0 HYDRA_CONFIG=../examples/configs/polygraph_eval_aeslc.yaml python ./examples/corrupt_dataset.py prompt='' model="facebook/opt-350m" 

ID dataset:
CUDA_VISIBLE_DEVICES=0 HYDRA_CONFIG=../examples/configs/polygraph_eval_aeslc.yaml python ./scripts/polygraph_eval device="cuda:0" batch_size=1 subsample_train_dataset=100 subsample_background_train_dataset=100 model="facebook/opt-350m" subsample_eval_dataset=100

OOD dataset:
CUDA_VISIBLE_DEVICES=0 HYDRA_CONFIG=../examples/configs/polygraph_eval_aeslc.yaml python ./scripts/polygraph_eval device="cuda:0" batch_size=1 model="facebook/opt-350m" dataset=./workdir/output/ats/facebook/opt-350m/aeslc/2023-11-22/15-47-17/aeslc_corrupted.csv text_column=email_body_corrupted label_column=subject_line subsample_eval_dataset=100 +parameters_path=./workdir/output/density_stats/aeslc/opt-350m

OOD detection:
CUDA_VISIBLE_DEVICES=0 HYDRA_CONFIG=../examples/configs/polygraph_eval_ood.yaml python ./scripts/polygraph_eval_ood model="facebook/opt-350m" id_manager_path=./workdir/output/ats/facebook/opt-350m/aeslc/2023-11-22/15-48-05/ue_manager_seed1 ood_manager_path=./workdir/output/ats/facebook/opt-350m/workdir/output/ats/facebook/opt-350m/aeslc/2023-11-22/15-47-17/aeslc_corrupted.csv/2023-11-22/16-16-20/ue_manager_seed1
