### PR TITLE
Automatic publish to PyPI when creating new release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,48 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Assign release version to package version
+      run: |
+        new_version=${{ github.event.release.tag_name }}
+        new_version="${new_version:1}"
+        echo Package will have new version $new_version
+        
+        tmp_file=$(mktemp)
+        sed s/0.0.0/$new_version/ pyproject.toml > $tmp_file
+        cat $tmp_file > pyproject.toml
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm_polygraph"
-version = "0.0.2.dev1"
+version = "0.0.0"
 authors = [
   { name = "List of contributors: https://github.com/IINemo/lm-polygraph/graphs/contributors", email = "artemshelmanov@gmail.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,3 @@ unbabel-comet==2.2.1
 nltk>=3.7,<4
 evaluate
 spacy>=3.4.0,<4
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl

--- a/src/lm_polygraph/generation_metrics/alignscore_utils.py
+++ b/src/lm_polygraph/generation_metrics/alignscore_utils.py
@@ -41,9 +41,20 @@ class AlignScorer:
         try:
             spacy.load("en_core_web_sm")
         except OSError:
-            subprocess.check_call([sys.executable, "-m", "pip", "install",
-                "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl",
-                "--retries", "1", "--timeout", "1", "-q"])
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl",
+                    "--retries",
+                    "1",
+                    "--timeout",
+                    "1",
+                    "-q",
+                ]
+            )
         self.model = Inferencer(
             ckpt_path=ckpt_path,
             model=model,

--- a/src/lm_polygraph/generation_metrics/alignscore_utils.py
+++ b/src/lm_polygraph/generation_metrics/alignscore_utils.py
@@ -1,6 +1,8 @@
 # the code adapted from https://github.com/yuh-zha/AlignScore
 import os
 import math
+import subprocess
+import sys
 import spacy
 from typing import Optional, Tuple
 from transformers import (
@@ -36,6 +38,12 @@ class AlignScorer:
         evaluation_mode="nli_sp",
         verbose=True,
     ) -> None:
+        try:
+            spacy.load("en_core_web_sm")
+        except OSError:
+            subprocess.check_call([sys.executable, "-m", "pip", "install",
+                "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl",
+                "--retries", "1", "--timeout", "1", "-q"])
         self.model = Inferencer(
             ckpt_path=ckpt_path,
             model=model,


### PR DESCRIPTION
In this commit I created new Github Action that does the following:
1. Detects when new release is created
2. Reads release version and assigns it to package version
3. Publishes package to PyPI

It also needs pypi token to be set in secrets
It also requires all release versions to be in format "v{some correct new version of pypi}", e.g. v0.1.2.dev3

I also removed en-core-web-sm package dependency, since I couldn't release package because of it
Now it will be installed at runtime in code