### PR TITLE
Fix/registers

### DIFF
--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -230,30 +230,23 @@ def get_density_based_ue_methods(args, model_type):
         if model_type == "Seq2SeqLM":
             estimators += [
                 MahalanobisDistanceSeq("encoder", parameters_path=parameters_path),
-                MahalanobisDistanceSeq("decoder", parameters_path=parameters_path),
                 RelativeMahalanobisDistanceSeq(
                     "encoder", parameters_path=parameters_path
                 ),
-                RelativeMahalanobisDistanceSeq(
-                    "decoder", parameters_path=parameters_path
-                ),
                 RDESeq("encoder", parameters_path=parameters_path),
-                RDESeq("decoder", parameters_path=parameters_path),
                 PPLMDSeq("encoder", md_type="MD", parameters_path=parameters_path),
                 PPLMDSeq("encoder", md_type="RMD", parameters_path=parameters_path),
-                PPLMDSeq("decoder", md_type="MD", parameters_path=parameters_path),
-                PPLMDSeq("decoder", md_type="RMD", parameters_path=parameters_path),
             ]
-        else:
-            estimators += [
-                MahalanobisDistanceSeq("decoder", parameters_path=parameters_path),
-                RelativeMahalanobisDistanceSeq(
-                    "decoder", parameters_path=parameters_path
-                ),
-                RDESeq("decoder", parameters_path=parameters_path),
-                PPLMDSeq("decoder", md_type="MD", parameters_path=parameters_path),
-                PPLMDSeq("decoder", md_type="RMD", parameters_path=parameters_path),
-            ]
+
+        estimators += [
+            MahalanobisDistanceSeq("decoder", parameters_path=parameters_path),
+            RelativeMahalanobisDistanceSeq(
+                "decoder", parameters_path=parameters_path
+            ),
+            RDESeq("decoder", parameters_path=parameters_path),
+            PPLMDSeq("decoder", md_type="MD", parameters_path=parameters_path),
+            PPLMDSeq("decoder", md_type="RMD", parameters_path=parameters_path),
+        ]
     return estimators
 
 

--- a/src/lm_polygraph/generation_metrics/alignscore.py
+++ b/src/lm_polygraph/generation_metrics/alignscore.py
@@ -18,8 +18,7 @@ class AlignScore(GenerationMetric):
         ckpt_path="https://huggingface.co/yzha/AlignScore/resolve/main/AlignScore-large.ckpt",
     ):
         super().__init__(["greedy_texts", "input_texts"], "sequence")
-        # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        device = torch.device("mps")
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.scorer = AlignScorer(
             model="roberta-large",
             batch_size=16,

--- a/src/lm_polygraph/generation_metrics/alignscore.py
+++ b/src/lm_polygraph/generation_metrics/alignscore.py
@@ -18,7 +18,7 @@ class AlignScore(GenerationMetric):
         ckpt_path="https://huggingface.co/yzha/AlignScore/resolve/main/AlignScore-large.ckpt",
     ):
         super().__init__(["greedy_texts", "input_texts"], "sequence")
-        #device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         device = torch.device("mps")
         self.scorer = AlignScorer(
             model="roberta-large",

--- a/src/lm_polygraph/generation_metrics/alignscore.py
+++ b/src/lm_polygraph/generation_metrics/alignscore.py
@@ -18,7 +18,8 @@ class AlignScore(GenerationMetric):
         ckpt_path="https://huggingface.co/yzha/AlignScore/resolve/main/AlignScore-large.ckpt",
     ):
         super().__init__(["greedy_texts", "input_texts"], "sequence")
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        #device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = torch.device("mps")
         self.scorer = AlignScorer(
             model="roberta-large",
             batch_size=16,

--- a/src/lm_polygraph/stat_calculators/__init__.py
+++ b/src/lm_polygraph/stat_calculators/__init__.py
@@ -1,7 +1,9 @@
 from .stat_calculator import StatCalculator
 from .greedy_probs import GreedyProbsCalculator, BlackboxGreedyTextsCalculator
 from .greedy_lm_probs import GreedyLMProbsCalculator
-from .prompt import PromptCalculator
+from .prompt import (PromptCalculator,
+                     SamplingPromptCalculator,
+                     ClaimPromptCalculator)
 from .entropy import EntropyCalculator
 from .sample import SamplingGenerationCalculator, BlackboxSamplingGenerationCalculator
 from .greedy_alternatives_nli import (

--- a/src/lm_polygraph/stat_calculators/__init__.py
+++ b/src/lm_polygraph/stat_calculators/__init__.py
@@ -1,9 +1,7 @@
 from .stat_calculator import StatCalculator
 from .greedy_probs import GreedyProbsCalculator, BlackboxGreedyTextsCalculator
 from .greedy_lm_probs import GreedyLMProbsCalculator
-from .prompt import (PromptCalculator,
-                     SamplingPromptCalculator,
-                     ClaimPromptCalculator)
+from .prompt import PromptCalculator, SamplingPromptCalculator, ClaimPromptCalculator
 from .entropy import EntropyCalculator
 from .sample import SamplingGenerationCalculator, BlackboxSamplingGenerationCalculator
 from .greedy_alternatives_nli import (

--- a/src/lm_polygraph/stat_calculators/bart_score.py
+++ b/src/lm_polygraph/stat_calculators/bart_score.py
@@ -1,6 +1,6 @@
 # %%
 import traceback
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 import numpy as np
 import torch
@@ -13,10 +13,18 @@ from lm_polygraph.utils.model import WhiteboxModel
 
 
 class BartScoreCalculator(StatCalculator):
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["rh"], ["greedy_tokens", "input_tokens"]
+
     def __init__(
         self, device=None, max_length=256, checkpoint="facebook/bart-large-cnn"
     ):
-        super().__init__(["rh"], ["greedy_tokens", "input_tokens"])
+        super().__init__()
         self.max_length = max_length
         self.checkpoint = checkpoint
         self.device = device

--- a/src/lm_polygraph/stat_calculators/cross_encoder_similarity.py
+++ b/src/lm_polygraph/stat_calculators/cross_encoder_similarity.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import itertools
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .stat_calculator import StatCalculator
 from sentence_transformers import CrossEncoder
@@ -13,16 +13,20 @@ class CrossEncoderSimilarityMatrixCalculator(StatCalculator):
     Calculates the cross-encoder similarity matrix for generation samples using RoBERTa model.
     """
 
-    def __init__(self, nli_model):
-        super().__init__(
-            [
-                "sample_sentence_similarity",
-                "sample_token_similarity",
-                "token_similarity",
-            ],
-            ["input_texts", "sample_tokens", "sample_texts", "greedy_tokens"],
-        )
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
 
+        return [
+            "sample_sentence_similarity",
+            "sample_token_similarity",
+            "token_similarity",
+        ], ["input_texts", "sample_tokens", "sample_texts", "greedy_tokens"]
+
+    def __init__(self, nli_model):
+        super().__init__()
         self.crossencoder_setup = False
         self.nli_model = nli_model
 

--- a/src/lm_polygraph/stat_calculators/embeddings.py
+++ b/src/lm_polygraph/stat_calculators/embeddings.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .stat_calculator import StatCalculator
 from lm_polygraph.utils.model import WhiteboxModel
@@ -159,8 +159,16 @@ def aggregate(x, aggregation_method, axis):
 
 
 class EmbeddingsCalculator(StatCalculator):
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["train_embeddings", "background_train_embeddings"], []
+
     def __init__(self):
-        super().__init__(["train_embeddings", "background_train_embeddings"], [])
+        super().__init__()
         self.hidden_layer = -1
 
     def __call__(

--- a/src/lm_polygraph/stat_calculators/ensemble_token_data.py
+++ b/src/lm_polygraph/stat_calculators/ensemble_token_data.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from functools import partial
 
 import torch
@@ -12,8 +12,16 @@ from lm_polygraph.utils.token_restoration import (
 
 
 class EnsembleTokenLevelDataCalculator(StatCalculator):
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["ensemble_token_scores"], []
+
     def __init__(self):
-        super().__init__(["ensemble_token_scores"], [])
+        super().__init__()
 
     def __call__(
         self,

--- a/src/lm_polygraph/stat_calculators/entropy.py
+++ b/src/lm_polygraph/stat_calculators/entropy.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .stat_calculator import StatCalculator
 from lm_polygraph.utils.model import WhiteboxModel
@@ -11,8 +11,16 @@ class EntropyCalculator(StatCalculator):
     Calculates entropy of probabilities at each token position in the generation of a Whitebox model.
     """
 
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["entropy"], ["greedy_log_probs"]
+
     def __init__(self):
-        super().__init__(["entropy"], ["greedy_log_probs"])
+        super().__init__()
 
     def __call__(
         self,

--- a/src/lm_polygraph/stat_calculators/extract_claims.py
+++ b/src/lm_polygraph/stat_calculators/extract_claims.py
@@ -44,6 +44,7 @@ class ClaimsExtractor(StatCalculator):
     """
     Extracts claims from the text of the model generation.
     """
+
     @staticmethod
     def meta_info() -> Tuple[List[str], List[str]]:
         """

--- a/src/lm_polygraph/stat_calculators/extract_claims.py
+++ b/src/lm_polygraph/stat_calculators/extract_claims.py
@@ -1,6 +1,6 @@
 import re
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass
 
 from .stat_calculator import StatCalculator
@@ -44,19 +44,23 @@ class ClaimsExtractor(StatCalculator):
     """
     Extracts claims from the text of the model generation.
     """
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the SamplingPromptCalculator.
+        """
+
+        return [
+            "claims",
+            "claim_texts_concatenated",
+            "claim_input_texts_concatenated",
+        ], [
+            "greedy_texts",
+            "greedy_tokens",
+        ]
 
     def __init__(self, openai_chat: OpenAIChat, sent_separators: str = ".?!\n"):
-        super().__init__(
-            [
-                "claims",
-                "claim_texts_concatenated",
-                "claim_input_texts_concatenated",
-            ],
-            [
-                "greedy_texts",
-                "greedy_tokens",
-            ],
-        )
+        super().__init__()
         self.openai_chat = openai_chat
         self.sent_separators = sent_separators
 

--- a/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
+++ b/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
@@ -42,14 +42,15 @@ def _eval_nli_model(nli_queue: List[Tuple[str, str]], deberta: Deberta) -> List[
 
 
 class GreedyAlternativesNLICalculator(StatCalculator):
-    def __init__(self, nli_model):
-        super().__init__(
-            [
-                "greedy_tokens_alternatives_nli",
-            ],
-            ["greedy_tokens_alternatives"],
-        )
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the SamplingPromptCalculator.
+        """
+        return ["greedy_tokens_alternatives_nli"], ["greedy_tokens_alternatives"]
 
+    def __init__(self, nli_model):
+        super().__init__()
         self.nli_model = nli_model
 
     def _strip(self, w: str):
@@ -105,18 +106,20 @@ class GreedyAlternativesNLICalculator(StatCalculator):
 
 
 class GreedyAlternativesFactPrefNLICalculator(StatCalculator):
-    def __init__(self, nli_model):
-        super().__init__(
-            [
-                "greedy_tokens_alternatives_fact_pref_nli",
-            ],
-            [
-                "greedy_tokens_alternatives",
-                "greedy_tokens",
-                "claims",
-            ],
-        )
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the SamplingPromptCalculator.
+        """
 
+        return ["greedy_tokens_alternatives_fact_pref_nli"], [
+            "greedy_tokens_alternatives",
+            "greedy_tokens",
+            "claims",
+        ]
+
+    def __init__(self, nli_model):
+        super().__init__()
         self.nli_model = nli_model
 
     def _strip(self, w: str):

--- a/src/lm_polygraph/stat_calculators/greedy_lm_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_lm_probs.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .stat_calculator import StatCalculator
 from lm_polygraph.utils.model import WhiteboxModel
@@ -13,10 +13,16 @@ class GreedyLMProbsCalculator(StatCalculator):
     Used to calculate P(y_t|y_<t) subtrahend in PointwiseMutualInformation.
     """
 
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["greedy_lm_log_probs", "greedy_lm_log_likelihoods"], ["greedy_tokens"]
+
     def __init__(self):
-        super().__init__(
-            ["greedy_lm_log_probs", "greedy_lm_log_likelihoods"], ["greedy_tokens"]
-        )
+        super().__init__()
 
     def __call__(
         self,

--- a/src/lm_polygraph/stat_calculators/greedy_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_probs.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .embeddings import get_embeddings_from_output
 from .stat_calculator import StatCalculator
@@ -13,8 +13,16 @@ class BlackboxGreedyTextsCalculator(StatCalculator):
     Calculates generation texts for Blackbox model (lm_polygraph.BlackboxModel).
     """
 
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["blackbox_greedy_texts"], []
+
     def __init__(self):
-        super().__init__(["blackbox_greedy_texts"], [])
+        super().__init__()
 
     def __call__(
         self,
@@ -53,23 +61,28 @@ class GreedyProbsCalculator(StatCalculator):
     * attention masks across the model (if applicable)
     * embeddings from the model
     """
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return [
+            "input_texts",
+            "input_tokens",
+            "greedy_log_probs",
+            "greedy_tokens",
+            "greedy_tokens_alternatives",
+            "greedy_texts",
+            "greedy_log_likelihoods",
+            "train_greedy_log_likelihoods",
+            "embeddings",
+            ], []
 
     def __init__(self, n_alternatives: int = 10):
-        super().__init__(
-            [
-                "input_texts",
-                "input_tokens",
-                "greedy_log_probs",
-                "greedy_tokens",
-                "greedy_tokens_alternatives",
-                "greedy_texts",
-                "greedy_log_likelihoods",
-                "train_greedy_log_likelihoods",
-                "embeddings",
-            ],
-            [],
-        )
+        super().__init__()
         self.n_alternatives = n_alternatives
+
 
     def __call__(
         self,

--- a/src/lm_polygraph/stat_calculators/greedy_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_probs.py
@@ -61,6 +61,7 @@ class GreedyProbsCalculator(StatCalculator):
     * attention masks across the model (if applicable)
     * embeddings from the model
     """
+
     @staticmethod
     def meta_info() -> Tuple[List[str], List[str]]:
         """
@@ -77,12 +78,11 @@ class GreedyProbsCalculator(StatCalculator):
             "greedy_log_likelihoods",
             "train_greedy_log_likelihoods",
             "embeddings",
-            ], []
+        ], []
 
     def __init__(self, n_alternatives: int = 10):
         super().__init__()
         self.n_alternatives = n_alternatives
-
 
     def __call__(
         self,

--- a/src/lm_polygraph/stat_calculators/model_score.py
+++ b/src/lm_polygraph/stat_calculators/model_score.py
@@ -3,7 +3,7 @@ import traceback
 import numpy as np
 
 from torch.nn.utils.rnn import pad_sequence
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 from .stat_calculator import StatCalculator
 from lm_polygraph.utils.model import WhiteboxModel
@@ -19,8 +19,16 @@ def _batch_tokens(tokens_list: List[List[int]], model: WhiteboxModel):
 
 
 class ModelScoreCalculator(StatCalculator):
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["model_rh"], ["greedy_tokens", "input_tokens"]
+
     def __init__(self, prompt: str = 'Paraphrase "{}": ', batch_size: int = 10):
-        super().__init__(["model_rh"], ["greedy_tokens", "input_tokens"])
+        super().__init__()
         self.batch_size = batch_size
         self.prompt = prompt
 

--- a/src/lm_polygraph/stat_calculators/prompt.py
+++ b/src/lm_polygraph/stat_calculators/prompt.py
@@ -114,10 +114,9 @@ class PromptCalculator(BasePromptCalculator):
 
         return ["p_true"], ["greedy_texts"]
 
-
     def __init__(self):
         super().__init__(
-            "Question: {q}\n Possible answer:{a}\n " \
+            "Question: {q}\n Possible answer:{a}\n "
             "Is the possible answer:\n (A) True\n (B) False\n The possible answer is:",
             "True",
             "p_true",
@@ -134,10 +133,9 @@ class SamplingPromptCalculator(BasePromptCalculator):
 
         return ["p_true_sampling"], ["greedy_texts", "sample_texts"]
 
-
     def __init__(self):
         super().__init__(
-            "Question: {q}\n Here are some ideas that were brainstormed: {s}\n Possible answer:{a}\n " \
+            "Question: {q}\n Here are some ideas that were brainstormed: {s}\n Possible answer:{a}\n "
             "Is the possible answer:\n (A) True\n (B) False\n The possible answer is:",
             "True",
             "p_true_sampling",
@@ -155,10 +153,9 @@ class ClaimPromptCalculator(BasePromptCalculator):
 
         return ["p_true_claim"], ["greedy_texts"]
 
-
     def __init__(self):
         super().__init__(
-            "Question: {q}\n Possible answer:{a}\n " \
+            "Question: {q}\n Possible answer:{a}\n "
             "Is the possible answer True or False? The possible answer is: ",
             "True",
             "p_true_claim",

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .stat_calculator import StatCalculator
 from lm_polygraph.utils.model import WhiteboxModel, BlackboxModel
@@ -12,13 +12,17 @@ class BlackboxSamplingGenerationCalculator(StatCalculator):
     Calculates several sampled texts for Blackbox model (lm_polygraph.BlackboxModel).
     """
 
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return ["blackbox_sample_texts"], []
+
     def __init__(self, samples_n: int = 10):
-        """
-        Parameters:
-            samples_n (int): number of samples to generate per input text. Default: 10
-        """
+        super().__init__()
         self.samples_n = samples_n
-        super().__init__(["blackbox_sample_texts"], [])
 
     def __call__(
         self,
@@ -85,22 +89,23 @@ class SamplingGenerationCalculator(StatCalculator):
     * tokens of the sampled texts
     * probabilities of the sampled tokens generation
     """
+    
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return [
+            "sample_log_probs",
+            "sample_tokens",
+            "sample_texts",
+            "sample_log_likelihoods",
+        ], []
 
     def __init__(self, samples_n: int = 10):
-        """
-        Parameters:
-            samples_n (int): number of samples to generate per input text. Default: 10
-        """
+        super().__init__()
         self.samples_n = samples_n
-        super().__init__(
-            [
-                "sample_log_probs",
-                "sample_tokens",
-                "sample_texts",
-                "sample_log_likelihoods",
-            ],
-            [],
-        )
 
     def __call__(
         self,

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -89,7 +89,7 @@ class SamplingGenerationCalculator(StatCalculator):
     * tokens of the sampled texts
     * probabilities of the sampled tokens generation
     """
-    
+
     @staticmethod
     def meta_info() -> Tuple[List[str], List[str]]:
         """

--- a/src/lm_polygraph/stat_calculators/semantic_matrix.py
+++ b/src/lm_polygraph/stat_calculators/semantic_matrix.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import itertools
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .stat_calculator import StatCalculator
 from lm_polygraph.utils.model import WhiteboxModel
@@ -16,17 +16,21 @@ class SemanticMatrixCalculator(StatCalculator):
     Calculates the NLI semantic matrix for generation samples using DeBERTa model.
     """
 
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Returns the statistics and dependencies for the calculator.
+        """
+
+        return [
+            "semantic_matrix_entail",
+            "semantic_matrix_contra",
+            "semantic_matrix_classes",
+            "entailment_id",
+        ], ["blackbox_sample_texts"]
+
     def __init__(self, nli_model):
-        super().__init__(
-            [
-                "semantic_matrix_entail",
-                "semantic_matrix_contra",
-                "semantic_matrix_classes",
-                "entailment_id",
-            ],
-            ["blackbox_sample_texts"],
-        )
-        self.is_deberta_setup = False
+        super().__init__()
         self.nli_model = nli_model
 
     def __call__(

--- a/src/lm_polygraph/stat_calculators/stat_calculator.py
+++ b/src/lm_polygraph/stat_calculators/stat_calculator.py
@@ -29,7 +29,6 @@ class StatCalculator(ABC):
 
         raise NotImplementedError("Implement stats_and_dependencies method")
 
-
     @polygraph_module_init
     def __init__(self):
         """

--- a/src/lm_polygraph/stat_calculators/stat_calculator.py
+++ b/src/lm_polygraph/stat_calculators/stat_calculator.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import List, Dict
+from typing import List, Dict, Tuple
 from abc import ABC, abstractmethod
 from lm_polygraph.utils.model import Model
 from lm_polygraph.utils.common import polygraph_module_init
@@ -21,8 +21,17 @@ class StatCalculator(ABC):
     Each new StatCalculator needs to be registered at lm_polygraph/stat_calculators/__init__.py to be seen be UEManager.
     """
 
+    @staticmethod
+    def meta_info() -> Tuple[List[str], List[str]]:
+        """
+        Placeholder method to return the list of statistics and dependencies for the calculator.
+        """
+
+        raise NotImplementedError("Implement stats_and_dependencies method")
+
+
     @polygraph_module_init
-    def __init__(self, stats: List[str], stat_dependencies: List[str]):
+    def __init__(self):
         """
         Parameters:
             stats: List[str]: Names of statiscits which can be calculated by using this StatCalculator.
@@ -30,8 +39,7 @@ class StatCalculator(ABC):
                 other StatCalculators. Any cycle dependencies among calculators will be spotted by UEManager and
                 end with an exception.
         """
-        self._stats = stats
-        self._stat_dependencies = stat_dependencies
+        self._stats, self._stat_dependencies = self._class.metainfo()
 
     @abstractmethod
     def __call__(

--- a/src/lm_polygraph/stat_calculators/stat_calculator.py
+++ b/src/lm_polygraph/stat_calculators/stat_calculator.py
@@ -39,7 +39,7 @@ class StatCalculator(ABC):
                 other StatCalculators. Any cycle dependencies among calculators will be spotted by UEManager and
                 end with an exception.
         """
-        self._stats, self._stat_dependencies = self._class.metainfo()
+        self._stats, self._stat_dependencies = self.__class__.meta_info()
 
     @abstractmethod
     def __call__(

--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -7,7 +7,7 @@ import os
 import logging
 
 from collections import defaultdict
-from typing import List, Set, Dict, Tuple, Optional
+from typing import List, Dict, Tuple, Optional
 from tqdm import tqdm
 from dataclasses import dataclass
 
@@ -26,6 +26,7 @@ from lm_polygraph.stat_calculators.stat_calculator import StatCalculator
 from lm_polygraph.utils.stat_resolver import StatResolver
 
 log = logging.getLogger("lm_polygraph")
+
 
 def _check_unique_names(xs):
     names = set()
@@ -256,7 +257,6 @@ class UEManager:
         _check_unique_names(estimators)
         _check_unique_names(ue_metrics)
 
-
         self.gen_metrics: Dict[Tuple[str, str], List[float]] = defaultdict(list)
         self.estimations: Dict[Tuple[str, str], List[float]] = defaultdict(list)
         self.metrics: Dict[Tuple[str, str, str, str], float] = {}
@@ -270,7 +270,6 @@ class UEManager:
         self.background_train_dataset_max_new_tokens = (
             background_train_dataset_max_new_tokens
         )
-
 
     def _resolve_stat_calculators(self):
         log.info("=" * 100)
@@ -311,8 +310,10 @@ class UEManager:
             )
         ]  # below in calculate() we copy X in blackbox_X
 
-        self.stat_calculators: List[StatCalculator] = self.stat_resolver.init_calculators(
-            [stat_calculators_dict[c] for c in stats]
+        self.stat_calculators: List[StatCalculator] = (
+            self.stat_resolver.init_calculators(
+                [stat_calculators_dict[c] for c in stats]
+            )
         )
         if self.verbose:
             print("Stat calculators:", self.stat_calculators)
@@ -344,10 +345,11 @@ class UEManager:
             stat_calculators_dict,
             stat_dependencies_dict,
         )
-        self.train_stat_calculators: List[StatCalculator] = \
+        self.train_stat_calculators: List[StatCalculator] = (
             self.stat_resolver.init_calculators(
                 [stat_calculators_dict[c] for c in train_stats]
             )
+        )
 
         background_train_stats = [
             s
@@ -360,10 +362,11 @@ class UEManager:
             stat_calculators_dict,
             stat_dependencies_dict,
         )
-        self.background_train_stat_calculators: List[StatCalculator] = \
+        self.background_train_stat_calculators: List[StatCalculator] = (
             self.stat_resolver.init_calculators(
                 [stat_calculators_dict[c] for c in background_train_stats]
             )
+        )
 
         ensemble_stats = [
             s
@@ -376,13 +379,13 @@ class UEManager:
             stat_calculators_dict,
             stat_dependencies_dict,
         )
-        self.ensemble_stat_calculators: List[StatCalculator] = \
+        self.ensemble_stat_calculators: List[StatCalculator] = (
             self.stat_resolver.init_calculators(
                 [stat_calculators_dict[c] for c in ensemble_stats]
             )
+        )
 
         log.info("Done intitializing stat calculators...")
-
 
     def __call__(self) -> Dict[Tuple[str, str, str, str], float]:
         """

--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -4,6 +4,7 @@ import torch
 import sys
 import gc
 import os
+import logging
 
 from collections import defaultdict
 from typing import List, Set, Dict, Tuple, Optional
@@ -24,6 +25,7 @@ from lm_polygraph.estimators.estimator import Estimator
 from lm_polygraph.stat_calculators.stat_calculator import StatCalculator
 from lm_polygraph.utils.stat_resolver import StatResolver
 
+log = logging.getLogger("lm_polygraph")
 
 def _check_unique_names(xs):
     names = set()
@@ -271,6 +273,9 @@ class UEManager:
 
 
     def _resolve_stat_calculators(self):
+        log.info("=" * 100)
+        log.info("Initializing stat calculators...")
+
         stat_calculators_dict = self.stat_resolver.stat_calculators
         stat_dependencies_dict = self.stat_resolver.stat_dependencies
 
@@ -375,6 +380,8 @@ class UEManager:
             self.stat_resolver.init_calculators(
                 [stat_calculators_dict[c] for c in ensemble_stats]
             )
+
+        log.info("Done intitializing stat calculators...")
 
 
     def __call__(self) -> Dict[Tuple[str, str, str, str], float]:

--- a/src/lm_polygraph/utils/register_stat_calculators.py
+++ b/src/lm_polygraph/utils/register_stat_calculators.py
@@ -10,80 +10,113 @@ from typing import Dict, List, Optional, Tuple
 log = logging.getLogger("lm_polygraph")
 
 
-def register_stat_calculators(
-    deberta_batch_size: int = 10,  # TODO: rename to NLI model
-    deberta_device: Optional[str] = None,  # TODO: rename to NLI model
-    n_ccp_alternatives: int = 10,
-    cache_path=os.path.expanduser("~") + "/.cache",
-) -> Tuple[Dict[str, "StatCalculator"], Dict[str, List[str]]]:
-    """
-    Registers all available statistic calculators to be seen by UEManager for properly organizing the calculations
-    order.
-    """
-    stat_calculators: Dict[str, "StatCalculator"] = {}
-    stat_dependencies: Dict[str, List[str]] = {}
+class Resolver:
+    def __init__(self):
+        self.stat_calculators, self.stat_dependencies = \
+            self.register_stat_calculators()
 
-    log.info("=" * 100)
-    log.info("Loading NLI model...")
-    nli_model = Deberta(batch_size=deberta_batch_size, device=deberta_device)
+    def _register_stat_calculators(
+        self,
+        deberta_batch_size: int = 10,  # TODO: rename to NLI model
+        deberta_device: Optional[str] = None,  # TODO: rename to NLI model
+        n_ccp_alternatives: int = 10,
+        cache_path=os.path.expanduser("~") + "/.cache",
+    ) -> Tuple[Dict[str, "StatCalculator"], Dict[str, List[str]]]:
+        """
+        Registers all available statistic calculators to be seen by UEManager for properly organizing the calculations
+        order.
+        """
+        stat_calculators: Dict[str, "StatCalculator"] = {}
+        stat_dependencies: Dict[str, List[str]] = {}
+>>>>>>> 9098ef0 (WiP)
 
-    log.info("=" * 100)
-    log.info("Initializing stat calculators...")
+        log.info("=" * 100)
+        log.info("Loading NLI model...")
+        #nli_model = Deberta(batch_size=deberta_batch_size, device=deberta_device)
+        nli_model = None
+        openai_chat = OpenAIChat(cache_path=cache_path)
 
-    openai_chat = OpenAIChat(cache_path=cache_path)
+        log.info("=" * 100)
+        log.info("Initializing stat calculators...")
 
-    def _register(calculator_class: StatCalculator):
-        for stat in calculator_class.stats:
-            if stat in stat_calculators.keys():
+        def _register(calculator_class: StatCalculator):
+            stats, dependencies = calculator_class.meta_info()
+            for stat in stats:
+                if stat in stat_calculators.keys():
+                    continue
+                stat_calculators[stat] = calculator_class
+                stat_dependencies[stat] = dependencies
+
+        _register(GreedyProbsCalculator)
+        _register(BlackboxGreedyTextsCalculator)
+        _register(EntropyCalculator)
+        _register(GreedyLMProbsCalculator)
+        _register(PromptCalculator)
+        _register(SamplingPromptCalculator)
+        _register(ClaimPromptCalculator)
+        _register(SamplingGenerationCalculator)
+        _register(BlackboxSamplingGenerationCalculator)
+        _register(BartScoreCalculator)
+        _register(ModelScoreCalculator)
+        _register(EmbeddingsCalculator)
+        _register(EnsembleTokenLevelDataCalculator)
+        _register(SemanticMatrixCalculator)
+        _register(CrossEncoderSimilarityMatrixCalculator)
+        _register(GreedyProbsCalculator)
+        _register(GreedyAlternativesNLICalculator)
+        _register(GreedyAlternativesFactPrefNLICalculator)
+        _register(ClaimsExtractor)
+
+        return stat_calculators, stat_dependencies
+
+
+    def _order_calculators(
+        self,
+        stats: List[str],
+        stat_calculators: Dict[str, StatCalculator],
+        stat_dependencies: Dict[str, List[str]],
+    ) -> Tuple[List[str], Set[str]]:
+        ordered: List[str] = []
+        have_stats: Set[str] = set()
+        while len(stats) > 0:
+            stat = stats[0]
+            if stat in have_stats:
+                stats = stats[1:]
                 continue
-            stat_calculators[stat] = calculator_class
-            stat_dependencies[stat] = calculator_class.stat_dependencies
+            dependent = False
+            if stat not in stat_dependencies.keys():
+                raise Exception(
+                    f"Cant find stat calculator for: {stat}. Maybe you forgot to register it in "
+                    + "lm_polygraph.utils.register_stat_calculators.register_stat_calculators()?"
+                )
+            for d in stat_dependencies[stat]:
+                if d not in have_stats:
+                    stats = [d] + stats
+                    if stats.count(d) > 40:
+                        raise Exception(f"Found possibly cyclic dependencies: {d}")
+                    dependent = True
+            if not dependent:
+                stats = stats[1:]
+                ordered.append(stat)
+                for new_stat in stat_calculators[stat].stats:
+                    have_stats.add(new_stat)
+        return ordered, have_stats
 
-    _register(GreedyProbsCalculator())
-    _register(BlackboxGreedyTextsCalculator())
-    _register(EntropyCalculator())
-    _register(GreedyLMProbsCalculator())
-    _register(
-        PromptCalculator(
-            "Question: {q}\n Possible answer:{a}\n "
-            "Is the possible answer:\n (A) True\n (B) False\n The possible answer is:",
-            "True",
-            "p_true",
-            sample_text_dependency=None,  # Not calculate T text samples for P(True)
-        )
-    )
-    _register(
-        PromptCalculator(
-            "Question: {q}\n Here are some ideas that were brainstormed: {s}\n Possible answer:{a}\n "
-            "Is the possible answer:\n (A) True\n (B) False\n The possible answer is:",
-            "True",
-            "p_true_sampling",
-        )
-    )
-    _register(
-        PromptCalculator(
-            "Question: {q}\n Possible answer:{a}\n "
-            "Is the possible answer True or False? The possible answer is: ",
-            "True",
-            "p_true_claim",
-            input_text_dependency="claim_input_texts_concatenated",
-            sample_text_dependency=None,
-            generation_text_dependency="claim_texts_concatenated",
-        )
-    )
-    _register(SamplingGenerationCalculator())
-    _register(BlackboxSamplingGenerationCalculator())
-    _register(BartScoreCalculator())
-    _register(ModelScoreCalculator())
-    _register(EmbeddingsCalculator())
-    _register(EnsembleTokenLevelDataCalculator())
-    _register(SemanticMatrixCalculator(nli_model=nli_model))
-    _register(CrossEncoderSimilarityMatrixCalculator(nli_model=nli_model))
-    _register(GreedyProbsCalculator(n_alternatives=n_ccp_alternatives))
-    _register(GreedyAlternativesNLICalculator(nli_model=nli_model))
-    _register(GreedyAlternativesFactPrefNLICalculator(nli_model=nli_model))
-    _register(ClaimsExtractor(openai_chat=openai_chat))
 
+<<<<<<< HEAD
     log.info("Done intitializing stat calculators...")
 
     return stat_calculators, stat_dependencies
+=======
+    def init_calculators(self, 
+        """
+        Initializes all calculators needed for the given list of estimators
+        """
+        ordered, have_stats = self._order_calculators(
+            stats, self.stat_calculators, self.stat_dependencies
+        )
+        calculators = []
+        for stat in ordered:
+            calculators.append(self.stat_calculators[stat])
+        return calculators
+>>>>>>> 9098ef0 (WiP)

--- a/src/lm_polygraph/utils/stat_resolver.py
+++ b/src/lm_polygraph/utils/stat_resolver.py
@@ -1,9 +1,6 @@
 import os
-<<<<<<< HEAD:src/lm_polygraph/utils/register_stat_calculators.py
 import logging
-=======
 import inspect
->>>>>>> 585519b (Move stat dependency resolution to resolver):src/lm_polygraph/utils/stat_resolver.py
 
 from lm_polygraph.stat_calculators import *
 from lm_polygraph.utils.deberta import Deberta
@@ -38,17 +35,11 @@ class StatResolver:
         Registers all available statistic calculators to be seen by UEManager
         for properly organizing the calculations order.
         """
-        stat_calculators: Dict[str, "StatCalculator"] = {}
-        stat_dependencies: Dict[str, List[str]] = {}
-
-        log.info("=" * 100)
-        log.info("Loading NLI model...")
-        #nli_model = Deberta(batch_size=deberta_batch_size, device=deberta_device)
-        nli_model = None
-        openai_chat = OpenAIChat(cache_path=cache_path)
-
         log.info("=" * 100)
         log.info("Initializing stat calculators...")
+
+        stat_calculators: Dict[str, "StatCalculator"] = {}
+        stat_dependencies: Dict[str, List[str]] = {}
 
         def _register(calculator_class: StatCalculator):
             stats, dependencies = calculator_class.meta_info()
@@ -111,19 +102,11 @@ class StatResolver:
                 ordered.append(stat)
                 for new_stat in stat_calculators[stat].meta_info()[0]:
                     have_stats.add(new_stat)
+
         return ordered, have_stats
 
 
-<<<<<<< HEAD:src/lm_polygraph/utils/register_stat_calculators.py
-<<<<<<< HEAD
-    log.info("Done intitializing stat calculators...")
-
-    return stat_calculators, stat_dependencies
-=======
-    def init_calculators(self, 
-=======
     def init_calculators(self, calculator_classes: List[StatCalculator]) -> List[StatCalculator]:
->>>>>>> 585519b (Move stat dependency resolution to resolver):src/lm_polygraph/utils/stat_resolver.py
         """
         Initializes all calculators needed for the given list of estimators
         """
@@ -136,6 +119,7 @@ class StatResolver:
                 # lazily to avoid unnecessary memory usage.
                 # It will be reused by all calculators that need it.
                 if self.nli_model is None:
+                    log.info("NLI model required by a calculator. Initializing...")
                     self.nli_model = Deberta(
                         batch_size=self.nli_model_batch_size,
                         device=self.nli_model_device
@@ -149,5 +133,6 @@ class StatResolver:
 
             calculators.append(_class(**args))
 
+        log.info("Done intitializing stat calculators...")
+
         return calculators
->>>>>>> 9098ef0 (WiP)

--- a/src/lm_polygraph/utils/stat_resolver.py
+++ b/src/lm_polygraph/utils/stat_resolver.py
@@ -16,7 +16,7 @@ class StatResolver:
         self,
         nli_model_batch_size: int = 10,
         nli_model_device: Optional[str] = None,
-        cache_path: str = os.path.expanduser("~") + "/.cache"
+        cache_path: str = os.path.expanduser("~") + "/.cache",
     ):
 
         self.nli_model_batch_size = nli_model_batch_size
@@ -25,11 +25,12 @@ class StatResolver:
         self.nli_model = None
         self.openai_chat = None
 
-        self.stat_calculators, self.stat_dependencies = \
+        self.stat_calculators, self.stat_dependencies = (
             self._register_stat_calculators()
+        )
 
     def _register_stat_calculators(
-        self
+        self,
     ) -> Tuple[Dict[str, "StatCalculator"], Dict[str, List[str]]]:
         """
         Registers all available statistic calculators to be seen by UEManager
@@ -68,7 +69,6 @@ class StatResolver:
 
         return stat_calculators, stat_dependencies
 
-
     def order_stats(
         self,
         stats: List[str],
@@ -102,8 +102,9 @@ class StatResolver:
 
         return ordered, have_stats
 
-
-    def init_calculators(self, calculator_classes: List[StatCalculator]) -> List[StatCalculator]:
+    def init_calculators(
+        self, calculator_classes: List[StatCalculator]
+    ) -> List[StatCalculator]:
         """
         Initializes all calculators needed for the given list of estimators
         """
@@ -116,13 +117,15 @@ class StatResolver:
                 # lazily to avoid unnecessary memory usage.
                 # It will be reused by all calculators that need it.
                 if self.nli_model is None:
-                    log.info(f"NLI model required by a calculator {_class}. Initializing...")
+                    log.info(
+                        f"NLI model required by a calculator {_class}. Initializing..."
+                    )
                     self.nli_model = Deberta(
                         batch_size=self.nli_model_batch_size,
-                        device=self.nli_model_device
+                        device=self.nli_model_device,
                     )
                 args["nli_model"] = self.nli_model
-            if "openai_chat" in init_params: 
+            if "openai_chat" in init_params:
                 # Same for OpenAI chat to reuse cache
                 if self.openai_chat is None:
                     self.openai_chat = OpenAIChat(cache_path=self.cache_path)

--- a/src/lm_polygraph/utils/stat_resolver.py
+++ b/src/lm_polygraph/utils/stat_resolver.py
@@ -35,9 +35,6 @@ class StatResolver:
         Registers all available statistic calculators to be seen by UEManager
         for properly organizing the calculations order.
         """
-        log.info("=" * 100)
-        log.info("Initializing stat calculators...")
-
         stat_calculators: Dict[str, "StatCalculator"] = {}
         stat_dependencies: Dict[str, List[str]] = {}
 
@@ -119,7 +116,7 @@ class StatResolver:
                 # lazily to avoid unnecessary memory usage.
                 # It will be reused by all calculators that need it.
                 if self.nli_model is None:
-                    log.info("NLI model required by a calculator. Initializing...")
+                    log.info(f"NLI model required by a calculator {_class}. Initializing...")
                     self.nli_model = Deberta(
                         batch_size=self.nli_model_batch_size,
                         device=self.nli_model_device
@@ -132,7 +129,5 @@ class StatResolver:
                 args["openai_chat"] = self.openai_chat
 
             calculators.append(_class(**args))
-
-        log.info("Done intitializing stat calculators...")
 
         return calculators

--- a/src/lm_polygraph/utils/stat_resolver.py
+++ b/src/lm_polygraph/utils/stat_resolver.py
@@ -1,34 +1,45 @@
 import os
+<<<<<<< HEAD:src/lm_polygraph/utils/register_stat_calculators.py
 import logging
+=======
+import inspect
+>>>>>>> 585519b (Move stat dependency resolution to resolver):src/lm_polygraph/utils/stat_resolver.py
 
 from lm_polygraph.stat_calculators import *
 from lm_polygraph.utils.deberta import Deberta
 from lm_polygraph.utils.openai_chat import OpenAIChat
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Set
 
 log = logging.getLogger("lm_polygraph")
 
 
-class Resolver:
-    def __init__(self):
+class StatResolver:
+    def __init__(
+        self,
+        nli_model_batch_size: int = 10,
+        nli_model_device: Optional[str] = None,
+        cache_path: str = os.path.expanduser("~") + "/.cache"
+    ):
+
+        self.nli_model_batch_size = nli_model_batch_size
+        self.nli_model_device = nli_model_device
+        self.cache_path = cache_path
+        self.nli_model = None
+        self.openai_chat = None
+
         self.stat_calculators, self.stat_dependencies = \
-            self.register_stat_calculators()
+            self._register_stat_calculators()
 
     def _register_stat_calculators(
-        self,
-        deberta_batch_size: int = 10,  # TODO: rename to NLI model
-        deberta_device: Optional[str] = None,  # TODO: rename to NLI model
-        n_ccp_alternatives: int = 10,
-        cache_path=os.path.expanduser("~") + "/.cache",
+        self
     ) -> Tuple[Dict[str, "StatCalculator"], Dict[str, List[str]]]:
         """
-        Registers all available statistic calculators to be seen by UEManager for properly organizing the calculations
-        order.
+        Registers all available statistic calculators to be seen by UEManager
+        for properly organizing the calculations order.
         """
         stat_calculators: Dict[str, "StatCalculator"] = {}
         stat_dependencies: Dict[str, List[str]] = {}
->>>>>>> 9098ef0 (WiP)
 
         log.info("=" * 100)
         log.info("Loading NLI model...")
@@ -70,7 +81,7 @@ class Resolver:
         return stat_calculators, stat_dependencies
 
 
-    def _order_calculators(
+    def order_stats(
         self,
         stats: List[str],
         stat_calculators: Dict[str, StatCalculator],
@@ -98,25 +109,45 @@ class Resolver:
             if not dependent:
                 stats = stats[1:]
                 ordered.append(stat)
-                for new_stat in stat_calculators[stat].stats:
+                for new_stat in stat_calculators[stat].meta_info()[0]:
                     have_stats.add(new_stat)
         return ordered, have_stats
 
 
+<<<<<<< HEAD:src/lm_polygraph/utils/register_stat_calculators.py
 <<<<<<< HEAD
     log.info("Done intitializing stat calculators...")
 
     return stat_calculators, stat_dependencies
 =======
     def init_calculators(self, 
+=======
+    def init_calculators(self, calculator_classes: List[StatCalculator]) -> List[StatCalculator]:
+>>>>>>> 585519b (Move stat dependency resolution to resolver):src/lm_polygraph/utils/stat_resolver.py
         """
         Initializes all calculators needed for the given list of estimators
         """
-        ordered, have_stats = self._order_calculators(
-            stats, self.stat_calculators, self.stat_dependencies
-        )
         calculators = []
-        for stat in ordered:
-            calculators.append(self.stat_calculators[stat])
+        for _class in calculator_classes:
+            init_params = list(inspect.signature(_class.__init__).parameters.keys())
+            args = {}
+            if "nli_model" in init_params:
+                # If the calculator needs the NLI model, we initialize it here
+                # lazily to avoid unnecessary memory usage.
+                # It will be reused by all calculators that need it.
+                if self.nli_model is None:
+                    self.nli_model = Deberta(
+                        batch_size=self.nli_model_batch_size,
+                        device=self.nli_model_device
+                    )
+                args["nli_model"] = self.nli_model
+            if "openai_chat" in init_params: 
+                # Same for OpenAI chat to reuse cache
+                if self.openai_chat is None:
+                    self.openai_chat = OpenAIChat(cache_path=self.cache_path)
+                args["openai_chat"] = self.openai_chat
+
+            calculators.append(_class(**args))
+
         return calculators
 >>>>>>> 9098ef0 (WiP)


### PR DESCRIPTION
This PR does the following:

- Implements new class - StatResolver, where `register_stat_calculators` function now lives.
- Moves most of the stat calculator resolution from manager to this new class
- Moves stats and dependencies of calculators to class-level function `meta_info`
- StatResolver registers all StatCalculators without instantiating
- Then inits only stat calculators that are needed for this particular run
- NLI model and OpenAIChat are only created once there is need to init calculator that requires it
- Stat calculator resolution now triggered only when Manager starts running (__call__) to make loading saved managers faster
- Some refactoring here and there