### PR TITLE
Direct model api

### DIFF
--- a/src/lm_polygraph/stat_calculators/bart_score.py
+++ b/src/lm_polygraph/stat_calculators/bart_score.py
@@ -143,7 +143,7 @@ class BartScoreCalculator(StatCalculator):
         if self.model is None:
             self._setup()
         srcs, tgts = dependencies["greedy_texts"], dependencies["target_texts"]
-        self.device = model.device()
+        self.device = model.device
         self.model.to(self.device)
 
         scores = {"rh": self.score(srcs, tgts)}

--- a/src/lm_polygraph/stat_calculators/cross_encoder_similarity.py
+++ b/src/lm_polygraph/stat_calculators/cross_encoder_similarity.py
@@ -38,7 +38,7 @@ class CrossEncoderSimilarityMatrixCalculator(StatCalculator):
         model: WhiteboxModel,
         max_new_tokens: int = 100,
     ) -> Dict[str, np.ndarray]:
-        device = model.device()
+        device = model.device
         tokenizer = model.tokenizer
 
         if not self.crossencoder_setup:

--- a/src/lm_polygraph/stat_calculators/embeddings.py
+++ b/src/lm_polygraph/stat_calculators/embeddings.py
@@ -173,7 +173,7 @@ class EmbeddingsCalculator(StatCalculator):
         batch: Dict[str, torch.Tensor] = model.tokenize(texts)
         batch = {k: v.to(model.device()) for k, v in batch.items()}
         with torch.no_grad():
-            out = model.generate(
+            out = model.pg_generate(
                 **batch,
                 output_scores=True,
                 return_dict_in_generate=True,

--- a/src/lm_polygraph/stat_calculators/embeddings.py
+++ b/src/lm_polygraph/stat_calculators/embeddings.py
@@ -171,7 +171,7 @@ class EmbeddingsCalculator(StatCalculator):
         max_new_tokens: int = 100,
     ) -> Dict[str, np.ndarray]:
         batch: Dict[str, torch.Tensor] = model.tokenize(texts)
-        batch = {k: v.to(model.device()) for k, v in batch.items()}
+        batch = {k: v.to(model.device) for k, v in batch.items()}
         with torch.no_grad():
             out = model.pg_generate(
                 **batch,

--- a/src/lm_polygraph/stat_calculators/ensemble_token_data.py
+++ b/src/lm_polygraph/stat_calculators/ensemble_token_data.py
@@ -26,7 +26,7 @@ class EnsembleTokenLevelDataCalculator(StatCalculator):
 
         batch: Dict[str, torch.Tensor] = model.tokenize(texts)
 
-        batch = {k: v.to(ensemble_model.device()) for k, v in batch.items()}
+        batch = {k: v.to(ensemble_model.device) for k, v in batch.items()}
         generation_params = dependencies["ensemble_generation_params"]
 
         max_length = generation_params.get("generation_max_length", max_new_tokens)

--- a/src/lm_polygraph/stat_calculators/ensemble_token_data.py
+++ b/src/lm_polygraph/stat_calculators/ensemble_token_data.py
@@ -46,7 +46,7 @@ class EnsembleTokenLevelDataCalculator(StatCalculator):
             generation_params["num_beams"] = num_return_sequences
 
         with torch.no_grad():
-            output = ensemble_model.generate(
+            output = ensemble_model.pg_generate(
                 **batch,
                 max_length=max_length,
                 min_length=min_length,

--- a/src/lm_polygraph/stat_calculators/greedy_lm_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_lm_probs.py
@@ -45,7 +45,7 @@ class GreedyLMProbsCalculator(StatCalculator):
         tokens = dependencies["greedy_tokens"]
         try:
             batch = model.tokenize([model.tokenizer.decode(t) for t in tokens])
-            batch = {k: v.to(model.device()) for k, v in batch.items()}
+            batch = {k: v.to(model.device) for k, v in batch.items()}
             with torch.no_grad():
                 if model.model_type == "Seq2SeqLM":
                     logprobs = model.model(
@@ -72,10 +72,10 @@ class GreedyLMProbsCalculator(StatCalculator):
             greedy_lm_log_probs = []
             greedy_lm_ll = []
             for toks in tokens:
-                input_ids = torch.LongTensor([toks]).to(model.device())
+                input_ids = torch.LongTensor([toks]).to(model.device)
                 batch = {
                     "input_ids": input_ids,
-                    "attention_mask": torch.ones_like(input_ids).to(model.device()),
+                    "attention_mask": torch.ones_like(input_ids).to(model.device),
                 }
                 with torch.no_grad():
                     if model.model_type == "Seq2SeqLM":

--- a/src/lm_polygraph/stat_calculators/greedy_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_probs.py
@@ -100,7 +100,7 @@ class GreedyProbsCalculator(StatCalculator):
         batch: Dict[str, torch.Tensor] = model.tokenize(texts)
         batch = {k: v.to(model.device()) for k, v in batch.items()}
         with torch.no_grad():
-            out = model.generate(
+            out = model.pg_generate(
                 **batch,
                 output_scores=True,
                 return_dict_in_generate=True,

--- a/src/lm_polygraph/stat_calculators/greedy_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_probs.py
@@ -98,7 +98,7 @@ class GreedyProbsCalculator(StatCalculator):
                 - 'greedy_log_likelihoods' (List[List[float]]): log-probabilities of the generated tokens.
         """
         batch: Dict[str, torch.Tensor] = model.tokenize(texts)
-        batch = {k: v.to(model.device()) for k, v in batch.items()}
+        batch = {k: v.to(model.device) for k, v in batch.items()}
         with torch.no_grad():
             out = model.pg_generate(
                 **batch,

--- a/src/lm_polygraph/stat_calculators/model_score.py
+++ b/src/lm_polygraph/stat_calculators/model_score.py
@@ -36,8 +36,8 @@ class ModelScoreCalculator(StatCalculator):
                     encoded_src = _batch_tokens(
                         [s + t for s, t in zip(src_list, tgt_list)], model
                     )
-                    src_tokens = encoded_src["input_ids"].to(model.device())
-                    src_mask = encoded_src["attention_mask"].to(model.device())
+                    src_tokens = encoded_src["input_ids"].to(model.device)
+                    src_mask = encoded_src["attention_mask"].to(model.device)
                     if model.model_type == "CausalLM":
                         logits = model(
                             input_ids=src_tokens,
@@ -47,9 +47,9 @@ class ModelScoreCalculator(StatCalculator):
                         encoded_src = _batch_tokens(src_list, model)
                         encoded_tgt = _batch_tokens(tgt_list, model)
 
-                        src_tokens = encoded_src["input_ids"].to(model.device())
-                        tgt_tokens = encoded_tgt["input_ids"].long().to(model.device())
-                        src_mask = encoded_src["attention_mask"].to(model.device())
+                        src_tokens = encoded_src["input_ids"].to(model.device)
+                        tgt_tokens = encoded_tgt["input_ids"].long().to(model.device)
+                        src_mask = encoded_src["attention_mask"].to(model.device)
 
                         logits = model(
                             input_ids=src_tokens,

--- a/src/lm_polygraph/stat_calculators/prompt.py
+++ b/src/lm_polygraph/stat_calculators/prompt.py
@@ -94,7 +94,7 @@ class PromptCalculator(StatCalculator):
         batch = {k: v.to(model.device()) for k, v in batch.items()}
 
         with torch.no_grad():
-            out = model.generate(
+            out = model.pg_generate(
                 **batch,
                 output_scores=True,
                 return_dict_in_generate=True,

--- a/src/lm_polygraph/stat_calculators/prompt.py
+++ b/src/lm_polygraph/stat_calculators/prompt.py
@@ -91,7 +91,7 @@ class PromptCalculator(StatCalculator):
             return {self.method: np.array([])}
 
         batch: Dict[str, torch.Tensor] = model.tokenize(inp_texts)
-        batch = {k: v.to(model.device()) for k, v in batch.items()}
+        batch = {k: v.to(model.device) for k, v in batch.items()}
 
         with torch.no_grad():
             out = model.pg_generate(

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -69,7 +69,7 @@ def _gen_samples(n_samples, model, batch, **kwargs):
     logits, sequences = [[] for _ in range(batch_size)], [[] for _ in range(batch_size)]
     with torch.no_grad():
         for k in range(n_samples):
-            out = model.generate(**batch, **kwargs)
+            out = model.pg_generate(**batch, **kwargs)
             cur_logits = torch.stack(out.scores, dim=1)
             for i in range(batch_size):
                 sequences[i].append(out.sequences[i])

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -125,7 +125,7 @@ class SamplingGenerationCalculator(StatCalculator):
                 - 'sample_log_likelihoods' (List[List[List[float]]]): log probabilities at each token of the sampling generation.
         """
         batch: Dict[str, torch.Tensor] = model.tokenize(texts)
-        batch = {k: v.to(model.device()) for k, v in batch.items()}
+        batch = {k: v.to(model.device) for k, v in batch.items()}
         sequences, logits = _gen_samples(
             self.samples_n,
             model,

--- a/src/lm_polygraph/utils/common.py
+++ b/src/lm_polygraph/utils/common.py
@@ -1,5 +1,7 @@
 import logging
 import importlib.util
+import numpy as np
+import pandas as pd
 
 from typing import Tuple
 
@@ -30,3 +32,9 @@ def load_external_module(path_to_file: str):
     spec.loader.exec_module(module)
 
     return module
+
+
+def is_list_like(obj):
+    """Check if object is list-like."""
+    valid_types = (list, tuple, set, np.ndarray, pd.Series)
+    return isinstance(obj, valid_types)

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -217,7 +217,7 @@ class BlackboxModel(Model):
 
         return texts
 
-    def generate(self, **args):
+    def pg_generate(self, **args):
         """
         Not implemented for blackbox models.
         """
@@ -361,8 +361,9 @@ class WhiteboxModel(Model):
             ]
         )
 
-    def generate(self, **args):
+    def pg_generate(self, **args):
         """
+        Polygraph-specific generation.
         Generates the model output with scores from batch formed by HF Tokenizer.
 
         Parameters:
@@ -370,7 +371,6 @@ class WhiteboxModel(Model):
         Returns:
             ModelOutput: HuggingFace generation output with scores overriden with original probabilities.
         """
-        print("Using WhiteboxModel.generate")
         default_params = asdict(self.generation_parameters)
 
         if len(self.generation_parameters.generate_until) > 0:

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -287,6 +287,16 @@ class WhiteboxModel(Model):
         self.tokenizer = tokenizer
         self.generation_parameters = generation_parameters
 
+    def __getattr__(self, method_name):
+        # Forward all unknown method calls to the model
+        # to align WhiteboxModel with HuggingFace model API
+        attr = getattr(self.model, method_name)
+        def method(*args, **kwargs):
+            return attr(*args, **kwargs)
+        if callable(attr):
+            return method
+        return attr
+
     class _ScoresProcessor:
         # Stores original token scores instead of the ones modified with generation parameters
         def __init__(self):
@@ -360,6 +370,7 @@ class WhiteboxModel(Model):
         Returns:
             ModelOutput: HuggingFace generation output with scores overriden with original probabilities.
         """
+        print("Using WhiteboxModel.generate")
         default_params = asdict(self.generation_parameters)
 
         if len(self.generation_parameters.generate_until) > 0:

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -428,15 +428,6 @@ class WhiteboxModel(Model):
         """
         return self.model(**args)
 
-    def device(self):
-        """
-        Returns the device the model is currently loaded on.
-
-        Returns:
-            str: device string.
-        """
-        return self.model.device
-
     @staticmethod
     def from_pretrained(
         model_path: str, generation_params: Optional[Dict] = {}, **kwargs

--- a/test_model_api.py
+++ b/test_model_api.py
@@ -1,0 +1,22 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from lm_polygraph.utils.model import WhiteboxModel
+from lm_polygraph.estimators import MaximumSequenceProbability
+
+name = "bigscience/bloomz-560m"
+model = AutoModelForCausalLM.from_pretrained(name)
+tok = AutoTokenizer.from_pretrained(name)
+
+wb = WhiteboxModel(model, tok)
+
+inputs = ["When was Albert Einstein born?", "What is the capital of France?"]
+tokenized = tok(inputs, return_tensors="pt", padding=True, truncation=True)
+
+ue_args = {
+    'estimators': [MaximumSequenceProbability()],
+}
+
+base_output, ue_output = wb.generate(**tokenized,
+                                     max_length=20,
+                                     num_return_sequences=1,
+                                     do_sample=True,
+                                     uncertainty_args=ue_args)


### PR DESCRIPTION
- Current `WhiteboxModel#generate` renamed to #pg_generate
- All calls to old generate renamed
- `WhiteboxModel` now acts like a proxy to it's underlying HF model - any unknown method calls will be redirected to it
- All calls to `WhiteboxModel#device()` replaced by `#device`, and old method removed - it will be responded by HF model directly
- New `WhiteboxModel#generate` method acts **exactly** like it's HF models method, and returns normal model output as it's first return value
- Second return value is result of `#estimate_uncertainty` call with the list of estimators specified as additional argument to #generate

Example of usage provided in temporary `test_model_api.py` script in the root.