### PR TITLE
Empirical baselines

### DIFF
--- a/examples/configs/instruct/cot_processing.yaml
+++ b/examples/configs/instruct/cot_processing.yaml
@@ -1,0 +1,6 @@
+process_output_fn:
+  - path: output_processing_scripts/default.py
+    fn_name: process_output_cot
+process_target_fn:
+  - path: output_processing_scripts/default.py
+    fn_name: process_target

--- a/examples/configs/instruct/cot_processing.yaml
+++ b/examples/configs/instruct/cot_processing.yaml
@@ -1,6 +1,6 @@
 process_output_fn:
-  - path: output_processing_scripts/default.py
-    fn_name: process_output_cot
+  path: output_processing_scripts/default.py
+  fn_name: process_output_cot
 process_target_fn:
-  - path: output_processing_scripts/default.py
-    fn_name: process_target
+  path: output_processing_scripts/default.py
+  fn_name: process_target

--- a/examples/configs/instruct/output_processing_scripts/default.py
+++ b/examples/configs/instruct/output_processing_scripts/default.py
@@ -1,8 +1,9 @@
 import re
 import string
 
-TOP1_OUTPUT_IGNORE_REGEX = re.compile("(?s).*Guess:|\n.*")
-TOPK_OUTPUT_IGNORE_REGEX = re.compile("(?s).*G1:|\n.*")
+TOP1_OUTPUT_IGNORE_REGEX = re.compile("(?s)[Gg]uess:|[\n\.\(\,].*")
+TOPK_OUTPUT_IGNORE_REGEX = re.compile("(?s)G1:|[\n\.\(\,].*")
+CoT_OUTPUT_IGNORE_REGEX = re.compile("(?s).*[Gg]uess:|[\n\.\(\,].*")
 
 
 def normalize_text(text: str) -> str:
@@ -24,5 +25,11 @@ def process_output_top1(output: str) -> str:
 
 def process_output_topk(output: str) -> str:
     output = TOPK_OUTPUT_IGNORE_REGEX.sub("", output)
+    output = normalize_text(output)
+    return output
+
+
+def process_output_cot(output: str) -> str:
+    output = CoT_OUTPUT_IGNORE_REGEX.sub("", output)
     output = normalize_text(output)
     return output

--- a/examples/configs/instruct/output_processing_scripts/default.py
+++ b/examples/configs/instruct/output_processing_scripts/default.py
@@ -1,9 +1,9 @@
 import re
 import string
 
-TOP1_OUTPUT_IGNORE_REGEX = re.compile("(?s)[Gg]uess:|[\n\.\(\,].*")
-TOPK_OUTPUT_IGNORE_REGEX = re.compile("(?s)G1:|[\n\.\(\,].*")
-CoT_OUTPUT_IGNORE_REGEX = re.compile("(?s).*[Gg]uess:|[\n\.\(\,].*")
+TOP1_OUTPUT_IGNORE_REGEX = re.compile(r"(?s)[Gg]uess:|[\n\.\(\,].*")
+TOPK_OUTPUT_IGNORE_REGEX = re.compile(r"(?s)G1:|[\n\.\(\,].*")
+CoT_OUTPUT_IGNORE_REGEX = re.compile(r"(?s).*[Gg]uess:|[\n\.\(\,].*")
 
 
 def normalize_text(text: str) -> str:

--- a/examples/configs/instruct/output_processing_scripts/default.py
+++ b/examples/configs/instruct/output_processing_scripts/default.py
@@ -1,0 +1,24 @@
+import re
+import string
+
+TOP1_OUTPUT_IGNORE_REGEX = re.compile("(?s).*Guess:|\n.*")
+TOPK_OUTPUT_IGNORE_REGEX = re.compile("(?s).*G1:|\n.*")
+
+def normalize_text(text: str) -> str:
+    text = text.strip().lower()
+    text = text.translate(str.maketrans("", "", string.punctuation))
+    return text
+
+def process_target(target: str) -> str:
+    target = normalize_text(target)
+    return target
+
+def process_output_top1(output: str) -> str:
+    output = TOP1_OUTPUT_IGNORE_REGEX.sub("", output)
+    output = normalize_text(output)
+    return output
+
+def process_output_topk(output: str) -> str:
+    output = TOPK_OUTPUT_IGNORE_REGEX.sub("", output)
+    output = normalize_text(output)
+    return output

--- a/examples/configs/instruct/output_processing_scripts/default.py
+++ b/examples/configs/instruct/output_processing_scripts/default.py
@@ -4,19 +4,23 @@ import string
 TOP1_OUTPUT_IGNORE_REGEX = re.compile("(?s).*Guess:|\n.*")
 TOPK_OUTPUT_IGNORE_REGEX = re.compile("(?s).*G1:|\n.*")
 
+
 def normalize_text(text: str) -> str:
     text = text.strip().lower()
     text = text.translate(str.maketrans("", "", string.punctuation))
     return text
 
+
 def process_target(target: str) -> str:
     target = normalize_text(target)
     return target
+
 
 def process_output_top1(output: str) -> str:
     output = TOP1_OUTPUT_IGNORE_REGEX.sub("", output)
     output = normalize_text(output)
     return output
+
 
 def process_output_topk(output: str) -> str:
     output = TOPK_OUTPUT_IGNORE_REGEX.sub("", output)

--- a/examples/configs/instruct/polygraph_eval_coqa_default_instruct.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_default_instruct.yaml
@@ -19,7 +19,6 @@ label_column: answers
 train_split: train
 eval_split: validation
 load_from_disk: false
-normalize: true
 generation_params: {}
 
 train_dataset: null

--- a/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
@@ -9,6 +9,9 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your be
 few_shot_prompt: "Question: {question}\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
+generation_params:
+  generate_until:
+    - "\n"
 
 use_seq_ue: true
 include_whitebox_ue: false

--- a/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
@@ -10,6 +10,8 @@ prompt: "Question: {question}\n"
 max_new_tokens: 30
 output_ignore_regex: "(?s).*Guess:"
 
+use_seq_ue: true
+include_whitebox_ue: false
 additional_estimators: 
   - module: lm_polygraph.estimators.semantic_entropy
     class_name: SemanticEntropy

--- a/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - polygraph_eval_coqa_default_instruct
+  - _self_
+
+experiment_name: coqa_empirical_baselines
+
+description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your best guess for the following question. Give ONLY the guess, no other words or explanation.\n\nFor example:\n\nGuess: <most likely guess, as short as possible; not a complete sentence, just the guess!>"
+few_shot_prompt: "Question: {question}\nGuess: {answer}"
+prompt: "Question: {question}\n"
+max_new_tokens: 30
+output_ignore_regex: "(?s).*Guess:"
+
+additional_estimators: 
+  - module: lm_polygraph.estimators.semantic_entropy
+    class_name: SemanticEntropy
+    kwargs:
+      class_probability_estimation: frequency
+  - module: lm_polygraph.estimators.p_true_empirical
+    class_name: PTrueEmpirical
+    kwargs: {}
+  - module: lm_polygraph.estimators.label_prob
+    class_name: LabelProb
+    kwargs: {}

--- a/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_empirical_baselines.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: coqa_empirical_baselines
@@ -8,7 +9,6 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your be
 few_shot_prompt: "Question: {question}\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
-output_ignore_regex: "(?s).*Guess:"
 
 use_seq_ue: true
 include_whitebox_ue: false

--- a/examples/configs/instruct/polygraph_eval_coqa_ling_1s.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_ling_1s.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: coqa_ling_1s
@@ -27,7 +28,7 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your be
 few_shot_prompt: "Question: {question}\nGuess: {answer}\nConfidence: <appropriate level of confidence in this guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 40
-output_ignore_regex: "(?s).*Guess: |\nConfidence:.*"
+
 
 additional_estimators: 
   - module: lm_polygraph.estimators.linguistic_1s

--- a/examples/configs/instruct/polygraph_eval_coqa_verb_1s_top1.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_verb_1s_top1.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: coqa_verb_1s_top1
@@ -8,7 +9,6 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your be
 few_shot_prompt: "Question: {question}\nGuess: {answer}\nProbability: <number between 0.0 and 1.0 reflecting confidence in the guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
-output_ignore_regex: "(?s).*Guess: |\nProbability.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_1s

--- a/examples/configs/instruct/polygraph_eval_coqa_verb_1s_topk.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_verb_1s_topk.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - topk_processing
   - _self_
 
 experiment_name: coqa_verb_1s_topk
@@ -9,7 +10,6 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your ${
 few_shot_prompt: "Question: {question}\nG1: {answer}\nP1: <number between 0.0 and 1.0 reflecting confidence in this guess>\n...\nG${topk}: <other guess>\nP${topk}: <probability of this guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 150
-output_ignore_regex: "(?s).*G1: |\nP1.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_1s

--- a/examples/configs/instruct/polygraph_eval_coqa_verb_2s_cot.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_verb_2s_cot.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: coqa_verb_2s_cot
@@ -8,7 +9,6 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your be
 few_shot_prompt: "Question: {question}\nExplanation: <step-by-step explanation of your thought process>\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 130
-output_ignore_regex: "(?s).*Guess:"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_coqa_verb_2s_cot.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_verb_2s_cot.yaml
@@ -1,6 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
-  - top1_processing
+  - cot_processing
   - _self_
 
 experiment_name: coqa_verb_2s_cot

--- a/examples/configs/instruct/polygraph_eval_coqa_verb_2s_top1.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_verb_2s_top1.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: coqa_verb_2s_top1
@@ -8,7 +9,6 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your be
 few_shot_prompt: "Question: {question}\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
-output_ignore_regex: "(?s).*Guess:"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_coqa_verb_2s_topk.yaml
+++ b/examples/configs/instruct/polygraph_eval_coqa_verb_2s_topk.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_coqa_default_instruct
+  - topk_processing
   - _self_
 
 experiment_name: coqa_verb_2s_topk
@@ -9,7 +10,6 @@ description: "Here's a short story:\n\n{story} (End of story)\n\nProvide your ${
 few_shot_prompt: "Question: {question}\nG1: {answer}\n...\nG${topk}: <other guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 125
-output_ignore_regex: "(?s).*G1:|G2:.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_mmlu_default_instruct.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_default_instruct.yaml
@@ -19,7 +19,6 @@ label_column: answer
 few_shot_split: dev
 train_split: validation
 eval_split: test
-  #max_new_tokens: 3
 load_from_disk: false
 n_shot: 5
 max_subject_size: 100

--- a/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
@@ -10,6 +10,8 @@ prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {ch
 max_new_tokens: 13
 output_ignore_regex: "(?s).*Guess:"
 
+use_seq_ue: true
+include_whitebox_ue: false
 additional_estimators: 
   - module: lm_polygraph.estimators.semantic_entropy
     class_name: SemanticEntropy

--- a/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
@@ -9,6 +9,9 @@ description: "Provide your best guess for the following question about {subject}
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nGuess:{answer}"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 13
+generation_params:
+  generate_until:
+    - "\n"
 
 use_seq_ue: true
 include_whitebox_ue: false

--- a/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - polygraph_eval_mmlu_default_instruct
+  - _self_
+
+experiment_name: mmlu_empirical_baselines
+
+description: "Provide your best guess for the following question about {subject} selecting one of the options. Give ONLY the guess, no other words or explanation.\n\nFor example:\n\nGuess: <most likely guess, only the selected option letter; not a complete sentence, just the guess!>"
+few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nGuess:{answer}"
+prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
+max_new_tokens: 13
+output_ignore_regex: "(?s).*Guess:"
+
+additional_estimators: 
+  - module: lm_polygraph.estimators.semantic_entropy
+    class_name: SemanticEntropy
+    kwargs:
+      class_probability_estimation: frequency
+  - module: lm_polygraph.estimators.p_true_empirical
+    class_name: PTrueEmpirical
+    kwargs: {}
+  - module: lm_polygraph.estimators.label_prob
+    class_name: LabelProb
+    kwargs: {}

--- a/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_empirical_baselines.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: mmlu_empirical_baselines
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question about {subject}
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nGuess:{answer}"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 13
-output_ignore_regex: "(?s).*Guess:"
 
 use_seq_ue: true
 include_whitebox_ue: false

--- a/examples/configs/instruct/polygraph_eval_mmlu_ling_1s.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_ling_1s.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: mmlu_ling_1s
@@ -27,7 +28,6 @@ description: "Provide your best guess for the following question about {subject}
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nGuess:{answer}\nConfidence: <appropriate level of confidence in this guess>"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 23
-output_ignore_regex: "(?s).*Guess: |\nConfidence:.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.linguistic_1s

--- a/examples/configs/instruct/polygraph_eval_mmlu_verb_1s_top1.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_verb_1s_top1.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: mmlu_verb_1s_top1
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question about {subject}
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nGuess:{answer}\nProbability: <number between 0.0 and 1.0 reflecting confidence in the guess>"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 23
-output_ignore_regex: "(?s).*Guess: |\nProbability.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_1s

--- a/examples/configs/instruct/polygraph_eval_mmlu_verb_1s_topk.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_verb_1s_topk.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - topk_processing
   - _self_
 
 experiment_name: mmlu_verb_1s_topk
@@ -9,7 +10,6 @@ description: "Provide your ${topk} best guesses for the following question about
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nG1: {answer}\nP1: <number between 0.0 and 1.0 reflecting confidence in this guess>\n...\nG${topk}: <other guess>\nP${topk}: <probability of this guess>"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 115
-output_ignore_regex: "(?s).*G1: |\nP1.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_1s

--- a/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_cot.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_cot.yaml
@@ -1,6 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
-  - top1_processing
+  - cot_processing
   - _self_
 
 experiment_name: mmlu_verb_2s_cot

--- a/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_cot.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_cot.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: mmlu_verb_2s_cot
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question about {subject}
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nExplanation: <step-by-step explanation of your thought process>\nGuess:{answer}"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 200
-output_ignore_regex: "(?s).*Guess:"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_top1.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_top1.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: mmlu_verb_2s_top1
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question about {subject}
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nGuess:{answer}"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 13
-output_ignore_regex: "(?s).*Guess:"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_topk.yaml
+++ b/examples/configs/instruct/polygraph_eval_mmlu_verb_2s_topk.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_mmlu_default_instruct
+  - topk_processing
   - _self_
 
 experiment_name: mmlu_verb_2s_topk
@@ -9,7 +10,6 @@ description: "Provide your ${topk} best guesses for the following question about
 few_shot_prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nG1: {answer}\n...\nG${topk}: <other guess>"
 prompt: "Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
 max_new_tokens: 65
-output_ignore_regex: "(?s).*G1:|G2:.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_triviaqa_default_instruct.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_default_instruct.yaml
@@ -22,7 +22,6 @@ eval_split: validation
 load_from_disk: false
 n_shot: 5
 multiref: true
-normalize: true
 generation_params: {}
 
 train_dataset: null

--- a/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
@@ -9,6 +9,9 @@ description: "Provide your best guess for the following question. Give ONLY the 
 few_shot_prompt: "Question: {question}\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
+generation_params:
+  generate_until:
+    - "\n"
 
 use_seq_ue: true
 include_whitebox_ue: false

--- a/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
@@ -10,6 +10,8 @@ prompt: "Question: {question}\n"
 max_new_tokens: 30
 output_ignore_regex: "(?s).*Guess:"
 
+use_seq_ue: true
+include_whitebox_ue: false
 additional_estimators: 
   - module: lm_polygraph.estimators.semantic_entropy
     class_name: SemanticEntropy

--- a/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - polygraph_eval_triviaqa_default_instruct
+  - _self_
+
+experiment_name: triviaqa_empirical_baselines
+
+description: "Provide your best guess for the following question. Give ONLY the guess, no other words or explanation.\n\nFor example:\n\nGuess: <most likely guess, as short as possible; not a complete sentence, just the guess!>"
+few_shot_prompt: "Question: {question}\nGuess: {answer}"
+prompt: "Question: {question}\n"
+max_new_tokens: 30
+output_ignore_regex: "(?s).*Guess:"
+
+additional_estimators: 
+  - module: lm_polygraph.estimators.semantic_entropy
+    class_name: SemanticEntropy
+    kwargs:
+      class_probability_estimation: frequency
+  - module: lm_polygraph.estimators.p_true_empirical
+    class_name: PTrueEmpirical
+    kwargs: {}
+  - module: lm_polygraph.estimators.label_prob
+    class_name: LabelProb
+    kwargs: {}

--- a/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_empirical_baselines.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: triviaqa_empirical_baselines
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question. Give ONLY the 
 few_shot_prompt: "Question: {question}\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
-output_ignore_regex: "(?s).*Guess:"
 
 use_seq_ue: true
 include_whitebox_ue: false

--- a/examples/configs/instruct/polygraph_eval_triviaqa_ling_1s.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_ling_1s.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: triviaqa_ling_1s
@@ -27,7 +28,6 @@ description: "Provide your best guess for the following question, and describe h
 few_shot_prompt: "Question: {question}\nGuess: {answer}\nConfidence: <appropriate level of confidence in this guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 40
-output_ignore_regex: "(?s).*Guess: |\nConfidence:.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.linguistic_1s

--- a/examples/configs/instruct/polygraph_eval_triviaqa_verb_1s_top1.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_verb_1s_top1.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: triviaqa_verb_1s_top1
@@ -8,7 +9,6 @@ description: "Provide your best guess and the probability that it is correct (0.
 few_shot_prompt: "Question: {question}\nGuess: {answer}\nProbability: <number between 0.0 and 1.0 reflecting confidence in the guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
-output_ignore_regex: "(?s).*Guess: |\nProbability.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_1s

--- a/examples/configs/instruct/polygraph_eval_triviaqa_verb_1s_topk.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_verb_1s_topk.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - topk_processing
   - _self_
 
 experiment_name: triviaqa_verb_1s_topk
@@ -9,7 +10,6 @@ description: "Provide your ${topk} best guesses and the probability that each is
 few_shot_prompt: "Question: {question}\nG1: {answer}\nP1: <number between 0.0 and 1.0 reflecting confidence in this guess>\n...\nG${topk}: <other guess>\nP${topk}: <probability of this guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 150
-output_ignore_regex: "(?s).*G1: |\nP1.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_1s

--- a/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_cot.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_cot.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: triviaqa_verb_2s_cot
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question. Before giving 
 few_shot_prompt: "Question: {question}\nExplanation: <step-by-step explanation of your thought process>\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 200
-output_ignore_regex: "(?s).*Guess:"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_cot.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_cot.yaml
@@ -1,6 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
-  - top1_processing
+  - cot_processing
   - _self_
 
 experiment_name: triviaqa_verb_2s_cot

--- a/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_top1.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_top1.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - top1_processing
   - _self_
 
 experiment_name: triviaqa_verb_2s_top1
@@ -8,7 +9,6 @@ description: "Provide your best guess for the following question. Give ONLY the 
 few_shot_prompt: "Question: {question}\nGuess: {answer}"
 prompt: "Question: {question}\n"
 max_new_tokens: 30
-output_ignore_regex: "(?s).*Guess:"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_topk.yaml
+++ b/examples/configs/instruct/polygraph_eval_triviaqa_verb_2s_topk.yaml
@@ -1,5 +1,6 @@
 defaults:
   - polygraph_eval_triviaqa_default_instruct
+  - topk_processing
   - _self_
 
 experiment_name: triviaqa_verb_2s_topk
@@ -9,7 +10,6 @@ description: "Provide your ${topk} best guesses for the following question. Give
 few_shot_prompt: "Question: {question}\nG1: {answer}\n...\nG${topk}: <other guess>"
 prompt: "Question: {question}\n"
 max_new_tokens: 125
-output_ignore_regex: "(?s).*G1:|G2:.*"
 
 additional_estimators: 
   - module: lm_polygraph.estimators.verbalized_2s

--- a/examples/configs/instruct/top1_processing.yaml
+++ b/examples/configs/instruct/top1_processing.yaml
@@ -1,0 +1,6 @@
+process_output_fn:
+  path: output_processing_scripts/default.py
+  fn_name: process_output_top1
+process_target_fn:
+  path: output_processing_scripts/default.py
+  fn_name: process_target

--- a/examples/configs/instruct/topk_processing.yaml
+++ b/examples/configs/instruct/topk_processing.yaml
@@ -1,0 +1,6 @@
+process_output_fn:
+  - path: output_processing_scripts/default.py
+    fn_name: process_output_topk
+process_target_fn:
+  - path: output_processing_scripts/default.py
+    fn_name: process_target

--- a/examples/configs/instruct/topk_processing.yaml
+++ b/examples/configs/instruct/topk_processing.yaml
@@ -1,6 +1,6 @@
 process_output_fn:
-  - path: output_processing_scripts/default.py
-    fn_name: process_output_topk
+  path: output_processing_scripts/default.py
+  fn_name: process_output_topk
 process_target_fn:
-  - path: output_processing_scripts/default.py
-    fn_name: process_target
+  path: output_processing_scripts/default.py
+  fn_name: process_target

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -405,7 +405,7 @@ def get_generation_metrics(args):
         for metric in generation_metrics:
             metric_name = metric["name"]
             metric_class = globals()[metric_name]
-            metric_args = metric.get("args", {})
+            metric_args = metric.get("args", [])
             result.append(metric_class(*metric_args))
 
     process_output_fn = getattr(args, "process_output_fn", None)

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -406,7 +406,7 @@ def get_generation_metrics(args):
             metric_name = metric["name"]
             metric_class = globals()[metric_name]
             metric_args = metric.get("args", {})
-            result.append(metric_class(**metric_args))
+            result.append(metric_class(*metric_args))
 
     process_output_fn = getattr(args, "process_output_fn", None)
     process_target_fn = getattr(args, "process_target_fn", None)

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -400,19 +400,38 @@ def get_generation_metrics(args):
         if args.task == "nmt":
             ignore_regex = getattr(args, "source_ignore_regex", None)
             result += [Comet(source_ignore_regex = ignore_regex)]
-
-        if getattr(args, "multiref", False):
-            # Wrap each metric in AggregatedMetric
-            result = [AggregatedMetric(base_metric=metric) for metric in result]
     else:
         result = []
         for metric in generation_metrics:
             metric_name = metric["name"]
-            if getattr(args, "multiref", False) and metric_name == "BartScoreSeqMetric":
-                raise ValueError("BartScoreSeqMetric does not support multiref")
             metric_class = globals()[metric_name]
-            result.append(metric_class(*metric.get("args", [])))
-    
+            metric_args = metric.get("args", {})
+            result.append(metric_class(**metric_args))
+
+    process_output_fn = getattr(args, "process_output_fn", None)
+    process_target_fn = getattr(args, "process_target_fn", None)
+    if process_target_fn or process_output_fn:
+        if (getattr(args, "target_ignore_regex", None) or 
+            getattr(args, "output_ignore_regex", None) or
+            getattr(args, "normalize", False)):
+            raise ValueError("Specifying ignore_regex or normalize simultaneously with process scripts is not allowed.")
+
+        def load_process_fn(fn_config):
+            if not fn_config:
+                return None
+            path = get_abs_path_from_hydra_config(fn_config.path)
+            module = load_external_module(path)
+            return getattr(module, fn_config.fn_name)
+
+        process_output_fn = load_process_fn(process_output_fn)
+        process_target_fn = load_process_fn(process_target_fn)
+
+        result = [PreprocessOutputTarget(metric, process_output_fn, process_target_fn) for metric in result]
+
+    if getattr(args, "multiref", False):
+        # Wrap each metric in AggregatedMetric
+        result = [AggregatedMetric(base_metric=metric) for metric in result]
+
     log.info("Done with initializing generation metrics.")
 
     return result
@@ -463,10 +482,9 @@ def get_whitebox_model(args, cache_kwargs={}):
             **cache_kwargs
         )
 
-    path_to_load_script = Path(args.model.path_to_load_script)
-    if not os.path.isabs(path_to_load_script):
-        path_to_load_script = hydra_config.parent / path_to_load_script
-
+    path_to_load_script = get_abs_path_from_hydra_config(
+            args.model.path_to_load_script
+        )
     load_module = load_external_module(path_to_load_script)
 
     load_model_args = {'model_path': args.model.path}
@@ -486,6 +504,14 @@ def get_whitebox_model(args, cache_kwargs={}):
                           generation_params)
 
     return model
+
+
+def get_abs_path_from_hydra_config(path: str) -> Path:
+    path = Path(path)
+    if not os.path.isabs(path):
+        path = hydra_config.parent / path
+
+    return path
 
 
 if __name__ == "__main__":

--- a/src/lm_polygraph/estimators/__init__.py
+++ b/src/lm_polygraph/estimators/__init__.py
@@ -69,3 +69,4 @@ from .fisher_rao import FisherRao
 from .verbalized_1s import Verbalized1S
 from .verbalized_2s import Verbalized2S
 from .linguistic_1s import Linguistic1S
+from .label_prob import LabelProb

--- a/src/lm_polygraph/estimators/__init__.py
+++ b/src/lm_polygraph/estimators/__init__.py
@@ -70,3 +70,4 @@ from .verbalized_1s import Verbalized1S
 from .verbalized_2s import Verbalized2S
 from .linguistic_1s import Linguistic1S
 from .label_prob import LabelProb
+from .p_true_empirical import PTrueEmpirical

--- a/src/lm_polygraph/estimators/label_prob.py
+++ b/src/lm_polygraph/estimators/label_prob.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from typing import Dict
+
+from .estimator import Estimator
+
+
+class LabelProb(Estimator):
+    def __init__(self):
+        super().__init__(["semantic_classes_entail"], "sequence")
+
+    def __str__(self):
+        return "LabelProb"
+
+    def __call__(self, stats: Dict[str, np.ndarray]) -> np.ndarray:
+        batch_class_to_sample = stats["semantic_classes_entail"]["class_to_sample"]
+        batch_sample_to_class = stats["semantic_classes_entail"]["sample_to_class"]
+
+        ues = []
+        for batch_i, class_to_sample in batch_class_to_sample.items():
+            num_samples = len(batch_sample_to_class[batch_i])
+            class_sizes = {k: len(v) for k, v in class_to_sample.items()}
+            largest_class = max(class_sizes, key=class_sizes.get)
+            ues.append(class_sizes[largest_class] / num_samples)
+
+        return np.array(ues)

--- a/src/lm_polygraph/estimators/label_prob.py
+++ b/src/lm_polygraph/estimators/label_prob.py
@@ -19,8 +19,7 @@ class LabelProb(Estimator):
         ues = []
         for batch_i, class_to_sample in batch_class_to_sample.items():
             num_samples = len(batch_sample_to_class[batch_i])
-            class_sizes = {k: len(v) for k, v in class_to_sample.items()}
-            largest_class = max(class_sizes, key=class_sizes.get)
-            ues.append(class_sizes[largest_class] / num_samples)
+            largest_class_size = max(len(samples) for samples in class_to_sample))
+            ues.append(1 - largest_class_size / num_samples)
 
         return np.array(ues)

--- a/src/lm_polygraph/estimators/label_prob.py
+++ b/src/lm_polygraph/estimators/label_prob.py
@@ -19,7 +19,7 @@ class LabelProb(Estimator):
         ues = []
         for batch_i, class_to_sample in batch_class_to_sample.items():
             num_samples = len(batch_sample_to_class[batch_i])
-            largest_class_size = max(len(samples) for samples in class_to_sample))
+            largest_class_size = max([len(samples) for samples in class_to_sample])
             ues.append(1 - largest_class_size / num_samples)
 
         return np.array(ues)

--- a/src/lm_polygraph/estimators/p_true_empirical.py
+++ b/src/lm_polygraph/estimators/p_true_empirical.py
@@ -20,14 +20,14 @@ class PTrueEmpirical(Estimator):
         
         ues = []
         for prompt, guess in zip(prompts, guesses):
-            input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\t(A) True or\n\t(B) False?\n The proposed answer is: "
-            tokens = model.tokenize([input])
+            input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\t(A) True or\n\t(B) False?\nThe proposed answer is: "
 
             out = model.generate_texts(
                 tokens,
                 min_new_tokens=1,
                 max_new_tokens=1,
                 num_return_sequences=self.num_samples,
+                do_sample=True,
             )
 
             ue = 1 - np.mean([1 if "True" in text else 0 for text in out])

--- a/src/lm_polygraph/estimators/p_true_empirical.py
+++ b/src/lm_polygraph/estimators/p_true_empirical.py
@@ -20,7 +20,7 @@ class PTrueEmpirical(Estimator):
         
         ues = []
         for prompt, guess in zip(prompts, guesses):
-            input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\t(A) True or\n\t(B) False?\nThe proposed answer is: "
+            input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\tTrue or\n\tFalse?\nThe proposed answer is: "
 
             out = model.generate_texts(
                 tokens,

--- a/src/lm_polygraph/estimators/p_true_empirical.py
+++ b/src/lm_polygraph/estimators/p_true_empirical.py
@@ -8,7 +8,7 @@ from .estimator import Estimator
 class PTrueEmpirical(Estimator):
     def __init__(self):
         self.num_samples = 10
-        super().__init__(["input_texts", "greedy_texts", "model"], "sequence")
+        super().__init__(["input_texts", "greedy_texts"], "sequence")
 
     def __str__(self):
         return "PTrueEmpirical"

--- a/src/lm_polygraph/estimators/p_true_empirical.py
+++ b/src/lm_polygraph/estimators/p_true_empirical.py
@@ -6,8 +6,8 @@ from .estimator import Estimator
 
 
 class PTrueEmpirical(Estimator):
-    def __init__(self):
-        self.num_samples = 10
+    def __init__(self, num_samples: int = 10):
+        self.num_samples = num_samples
         super().__init__(["input_texts", "greedy_texts"], "sequence")
 
     def __str__(self):
@@ -17,7 +17,7 @@ class PTrueEmpirical(Estimator):
         prompts = stats["input_texts"]
         guesses = stats["greedy_texts"]
         model = stats["model"]
-        
+
         ues = []
         for prompt, guess in zip(prompts, guesses):
             input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\tTrue or\n\tFalse?\nThe proposed answer is: "

--- a/src/lm_polygraph/estimators/p_true_empirical.py
+++ b/src/lm_polygraph/estimators/p_true_empirical.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from typing import Dict
+
+from .estimator import Estimator
+
+
+class PTrueEmpirical(Estimator):
+    def __init__(self):
+        self.num_samples = 10
+        super().__init__(["input_texts", "greedy_texts", "model"], "sequence")
+
+    def __str__(self):
+        return "PTrueEmpirical"
+
+    def __call__(self, stats: Dict[str, np.ndarray]) -> np.ndarray:
+        prompts = stats["input_texts"]
+        guesses = stats["greedy_texts"]
+        model = stats["model"]
+        
+        ues = []
+        for prompt, guess in zip(prompts, guesses):
+            input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\t(A) True or\n\t(B) False?\n The proposed answer is: "
+            tokens = model.tokenize([input])
+
+            out = model.generate_texts(
+                tokens,
+                min_new_tokens=1,
+                max_new_tokens=1,
+                num_return_sequences=self.num_samples,
+            )
+
+            ue = 1 - np.mean([1 if "True" in text else 0 for text in out])
+            ues.append(ue)
+
+        return np.array(ues)

--- a/src/lm_polygraph/estimators/p_true_empirical.py
+++ b/src/lm_polygraph/estimators/p_true_empirical.py
@@ -23,7 +23,7 @@ class PTrueEmpirical(Estimator):
             input = f"Question:\n\n{prompt}\n\nProposed Answer: {guess}\n\nIs the proposed answer:\n\tTrue or\n\tFalse?\nThe proposed answer is: "
 
             out = model.generate_texts(
-                tokens,
+                [input],
                 min_new_tokens=1,
                 max_new_tokens=1,
                 num_return_sequences=self.num_samples,

--- a/src/lm_polygraph/estimators/semantic_entropy.py
+++ b/src/lm_polygraph/estimators/semantic_entropy.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from collections import defaultdict
 from typing import List, Dict, Optional
 
 from .estimator import Estimator
@@ -17,7 +16,9 @@ class SemanticEntropy(Estimator):
     'samples_n' parameter.
     """
 
-    def __init__(self, verbose: bool = False, class_probability_estimation: str = "sum"):
+    def __init__(
+        self, verbose: bool = False, class_probability_estimation: str = "sum"
+    ):
         self.class_probability_estimation = class_probability_estimation
         if self.class_probability_estimation == "sum":
             deps = ["sample_log_probs", "sample_texts", "semantic_classes_entail"]
@@ -80,11 +81,17 @@ class SemanticEntropy(Estimator):
                     for class_idx in self._class_to_sample[i]
                 ]
                 class_lp = [
-                    np.logaddexp.reduce(likelihoods) for likelihoods in class_likelihoods
+                    np.logaddexp.reduce(likelihoods)
+                    for likelihoods in class_likelihoods
                 ]
             elif self.class_probability_estimation == "frequency":
                 num_samples = len(hyps_list[i])
-                class_lp = np.log([len(class_idx)/num_samples for class_idx in self._class_to_sample[i]])
+                class_lp = np.log(
+                    [
+                        len(class_idx) / num_samples
+                        for class_idx in self._class_to_sample[i]
+                    ]
+                )
 
             if log_weights[i] is None:
                 log_weights[i] = [0 for _ in hyps_list[i]]

--- a/src/lm_polygraph/estimators/semantic_entropy.py
+++ b/src/lm_polygraph/estimators/semantic_entropy.py
@@ -50,23 +50,22 @@ class SemanticEntropy(Estimator):
             np.ndarray: float semantic entropy for each sample in input statistics.
                 Higher values indicate more uncertain samples.
         """
-        loglikelihoods_list = stats["sample_log_probs"]
+        if self.class_probability_estimation == "sum":
+            loglikelihoods_list = stats["sample_log_probs"]
+            hyps_list = stats["sample_texts"]
+        elif self.class_probability_estimation == "frequency":
+            loglikelihoods_list = None
+            hyps_list = stats["blackbox_sample_texts"]
 
         self._class_to_sample = stats["semantic_classes_entail"]["class_to_sample"]
         self._sample_to_class = stats["semantic_classes_entail"]["sample_to_class"]
-
-        # Concatenate hypos with input texts
-        hyps_list = [[] for _ in stats["input_texts"]]
-        for i, input_text in enumerate(stats["input_texts"]):
-            for hyp in stats["sample_texts"][i]:
-                hyps_list[i].append(" ".join([input_text, hyp]))
 
         return self.batched_call(hyps_list, loglikelihoods_list)
 
     def batched_call(
         self,
         hyps_list: List[List[str]],
-        loglikelihoods_list: List[List[float]],
+        loglikelihoods_list: Optional[List[List[float]]],
         log_weights: Optional[List[List[float]]] = None,
     ) -> np.array:
         if log_weights is None:

--- a/src/lm_polygraph/estimators/semantic_entropy.py
+++ b/src/lm_polygraph/estimators/semantic_entropy.py
@@ -23,7 +23,7 @@ class SemanticEntropy(Estimator):
         if self.class_probability_estimation == "sum":
             deps = ["sample_log_probs", "sample_texts", "semantic_classes_entail"]
         elif self.class_probability_estimation == "frequency":
-            deps = ["blackbox_sample_texts", "semantic_classes_entail"]
+            deps = ["sample_texts", "semantic_classes_entail"]
         else:
             raise ValueError(
                 f"Unknown class_probability_estimation: {self.class_probability_estimation}. Use 'sum' or 'frequency'."
@@ -56,7 +56,7 @@ class SemanticEntropy(Estimator):
             hyps_list = stats["sample_texts"]
         elif self.class_probability_estimation == "frequency":
             loglikelihoods_list = None
-            hyps_list = stats["blackbox_sample_texts"]
+            hyps_list = stats["sample_texts"]
 
         self._class_to_sample = stats["semantic_classes_entail"]["class_to_sample"]
         self._sample_to_class = stats["semantic_classes_entail"]["sample_to_class"]

--- a/src/lm_polygraph/generation_metrics/__init__.py
+++ b/src/lm_polygraph/generation_metrics/__init__.py
@@ -9,3 +9,4 @@ from .openai_fact_check import OpenAIFactCheck
 from .bert_score import BertScoreMetric
 from .sbert import SbertMetric
 from .aggregated_metric import AggregatedMetric
+from .preprocess_output_target import PreprocessOutputTarget

--- a/src/lm_polygraph/generation_metrics/accuracy.py
+++ b/src/lm_polygraph/generation_metrics/accuracy.py
@@ -6,7 +6,8 @@ import logging
 from typing import List, Dict
 from .generation_metric import GenerationMetric
 
-log = logging.getLogger('lm_polygraph')
+log = logging.getLogger("lm_polygraph")
+
 
 class AccuracyMetric(GenerationMetric):
     """
@@ -25,10 +26,11 @@ class AccuracyMetric(GenerationMetric):
             re.compile(output_ignore_regex) if output_ignore_regex else None
         )
         self.normalize = normalize
-        
+
         if self.target_ignore_regex or self.output_ignore_regex or self.normalize:
             log.warning(
-                "Specifying ignore_regex or normalize in AccuracyMetric is deprecated. Use output and target processing scripts instead.")
+                "Specifying ignore_regex or normalize in AccuracyMetric is deprecated. Use output and target processing scripts instead."
+            )
 
     def __str__(self):
         return "Accuracy"

--- a/src/lm_polygraph/generation_metrics/accuracy.py
+++ b/src/lm_polygraph/generation_metrics/accuracy.py
@@ -1,10 +1,12 @@
 import re
 import string
 import numpy as np
+import logging
 
 from typing import List, Dict
 from .generation_metric import GenerationMetric
 
+log = logging.getLogger('lm_polygraph')
 
 class AccuracyMetric(GenerationMetric):
     """
@@ -23,6 +25,10 @@ class AccuracyMetric(GenerationMetric):
             re.compile(output_ignore_regex) if output_ignore_regex else None
         )
         self.normalize = normalize
+        
+        if self.target_ignore_regex or self.output_ignore_regex or self.normalize:
+            log.warning(
+                "Specifying ignore_regex or normalize in AccuracyMetric is deprecated. Use output and target processing scripts instead.")
 
     def __str__(self):
         return "Accuracy"

--- a/src/lm_polygraph/generation_metrics/aggregated_metric.py
+++ b/src/lm_polygraph/generation_metrics/aggregated_metric.py
@@ -16,7 +16,8 @@ class AggregatedMetric(GenerationMetric):
         self.aggregation = aggregation
 
     def __str__(self):
-        return str(self.base_metric)
+        # Check if base_metric is a wrapper, else return base_metric
+        return str(getattr(self.base_metric, "base_metric", self.base_metric))
 
     def __call__(
         self,

--- a/src/lm_polygraph/generation_metrics/alignscore.py
+++ b/src/lm_polygraph/generation_metrics/alignscore.py
@@ -52,19 +52,15 @@ class AlignScore(GenerationMetric):
         """
         greedy_texts = stats["greedy_texts"]
 
-        filtered_targets = [
-            x if len(x.strip()) else "(empty)" for x in target_texts
-        ]
-        filtered_outputs = [
-            x if len(x.strip()) else "(empty)" for x in greedy_texts
-        ]
+        filtered_targets = [x if len(x.strip()) else "(empty)" for x in target_texts]
+        filtered_outputs = [x if len(x.strip()) else "(empty)" for x in greedy_texts]
 
         if self.target_is_claims:
-            claims=filtered_targets
-            contexts=filtered_outputs
+            claims = filtered_targets
+            contexts = filtered_outputs
         else:
-            claims=filtered_outputs
-            contexts=filtered_targets
+            claims = filtered_outputs
+            contexts = filtered_targets
 
         scores = np.array(
             self.scorer.score(

--- a/src/lm_polygraph/generation_metrics/alignscore.py
+++ b/src/lm_polygraph/generation_metrics/alignscore.py
@@ -50,20 +50,27 @@ class AlignScore(GenerationMetric):
         Returns:
             np.ndarray: list of AlignScore Scores for each sample in input.
         """
+        greedy_texts = stats["greedy_texts"]
+
+        filtered_targets = [
+            x if len(x.strip()) else "(empty)" for x in target_texts
+        ]
+        filtered_outputs = [
+            x if len(x.strip()) else "(empty)" for x in greedy_texts
+        ]
+
         if self.target_is_claims:
-            scores = np.array(
-                self.scorer.score(
-                    claims=target_texts,
-                    contexts=stats["greedy_texts"],
-                )
-            )
+            claims=filtered_targets
+            contexts=filtered_outputs
         else:
-            scores = np.array(
-                self.scorer.score(
-                    claims=[
-                        x if len(x.strip()) else "-" for x in stats["greedy_texts"]
-                    ],  # fix for zero length generation
-                    contexts=target_texts,
-                )
+            claims=filtered_outputs
+            contexts=filtered_targets
+
+        scores = np.array(
+            self.scorer.score(
+                claims=claims,
+                contexts=contexts,
             )
+        )
+
         return scores

--- a/src/lm_polygraph/generation_metrics/bart_score.py
+++ b/src/lm_polygraph/generation_metrics/bart_score.py
@@ -1,9 +1,14 @@
-import numpy as np
+import traceback
 from typing import List, Dict
+
+import numpy as np
+import torch
+import torch.nn as nn
+from transformers import BartTokenizer, BartForConditionalGeneration
 
 from .generation_metric import GenerationMetric
 
-BART_SCORES = ["rh"]
+SCORE_TYPES = ["rh"]
 
 
 class BartScoreSeqMetric(GenerationMetric):
@@ -12,13 +17,114 @@ class BartScoreSeqMetric(GenerationMetric):
     between model-generated texts and ground truth texts.
     """
 
-    def __init__(self, score: str):
-        assert score in BART_SCORES
-        self.score = score
-        super().__init__(BART_SCORES, "sequence")
+    def __init__(
+            self,
+            score_type: str = "rh",
+            device=None,
+            max_length=256,
+            checkpoint="facebook/bart-large-cnn",
+        ):
+        assert score_type in SCORE_TYPES
+        self.score_type = score_type
+        self.model = None
+
+        self.max_length = max_length
+        self.checkpoint = checkpoint
+        self.device = device
+        if device is None:
+            self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+        self.tokenizer = None
+        self.model = None
+        self.loss_fct = None
+        self.lsm = None
+
+        super().__init__(["greedy_texts", "input_texts"], "sequence")
 
     def __str__(self):
-        return "BARTScoreSeq-" + self.score
+        return "BARTScoreSeq-" + self.score_type
+
+    def _setup(self):
+        self.tokenizer = BartTokenizer.from_pretrained(self.checkpoint)
+        self.model = BartForConditionalGeneration.from_pretrained(self.checkpoint)
+        self.model.eval()
+        self.model.to(self.device)
+
+        # Set up loss
+        self.loss_fct = nn.NLLLoss(
+            reduction="none", ignore_index=self.model.config.pad_token_id
+        )
+        self.lsm = nn.LogSoftmax(dim=1)
+
+    def load(self, path=None):
+        """Load model from paraphrase finetuning"""
+        if path is None:
+            path = "models/bart.pth"
+        if self.model is None:
+            self._setup()
+        self.model.load_state_dict(torch.load(path, map_location=self.device))
+
+    def score(self, srcs, tgts, batch_size=4):
+        """Score a batch of examples"""
+        if self.model is None:
+            self._setup()
+        score_list = []
+        for i in range(0, len(srcs), batch_size):
+            src_list = srcs[i : i + batch_size]
+            tgt_list = tgts[i : i + batch_size]
+            try:
+                with torch.no_grad():
+                    encoded_src = self.tokenizer(
+                        src_list,
+                        max_length=self.max_length,
+                        truncation=True,
+                        padding=True,
+                        return_tensors="pt",
+                    )
+                    encoded_tgt = self.tokenizer(
+                        tgt_list,
+                        max_length=self.max_length,
+                        truncation=True,
+                        padding=True,
+                        return_tensors="pt",
+                    )
+                    src_tokens = encoded_src["input_ids"].to(self.device)
+                    src_mask = encoded_src["attention_mask"].to(self.device)
+
+                    tgt_tokens = encoded_tgt["input_ids"].to(self.device)
+                    tgt_mask = encoded_tgt["attention_mask"]
+                    tgt_len = tgt_mask.sum(dim=1).to(self.device)
+
+                    output = self.model(
+                        input_ids=src_tokens, attention_mask=src_mask, labels=tgt_tokens
+                    )
+                    logits = output.logits.view(-1, self.model.config.vocab_size)
+                    loss = self.loss_fct(self.lsm(logits), tgt_tokens.view(-1))
+                    loss = loss.view(tgt_tokens.shape[0], -1)
+                    loss = loss.sum(dim=1) / tgt_len
+                    curr_score_list = [-x.item() for x in loss]
+                    score_list += curr_score_list
+
+            except RuntimeError:
+                traceback.print_exc()
+                print(f"source: {src_list}")
+                print(f"target: {tgt_list}")
+                exit(0)
+        return score_list
+
+    def test(self, batch_size=3):
+        """Test"""
+        if self.model is None:
+            self._setup()
+        src_list = [
+            "This is a very good idea. Although simple, but very insightful.",
+            "Can I take a look?",
+            "Do not trust him, he is a liar.",
+        ]
+
+        tgt_list = ["That's stupid.", "What's the problem?", "He is trustworthy."]
+
+        print(self.score(src_list, tgt_list, batch_size))
 
     def __call__(
         self,
@@ -36,4 +142,9 @@ class BartScoreSeqMetric(GenerationMetric):
         Returns:
             np.ndarray: list of BART Scores for each sample in input.
         """
-        return np.array(stats[self.score])
+        if self.model is None:
+            self._setup()
+
+        scores = self.score(stats["greedy_texts"], target_texts)
+
+        return np.array(scores)

--- a/src/lm_polygraph/generation_metrics/bart_score.py
+++ b/src/lm_polygraph/generation_metrics/bart_score.py
@@ -18,12 +18,12 @@ class BartScoreSeqMetric(GenerationMetric):
     """
 
     def __init__(
-            self,
-            score_type: str = "rh",
-            device=None,
-            max_length=256,
-            checkpoint="facebook/bart-large-cnn",
-        ):
+        self,
+        score_type: str = "rh",
+        device=None,
+        max_length=256,
+        checkpoint="facebook/bart-large-cnn",
+    ):
         assert score_type in SCORE_TYPES
         self.score_type = score_type
         self.model = None

--- a/src/lm_polygraph/generation_metrics/preprocess_output_target.py
+++ b/src/lm_polygraph/generation_metrics/preprocess_output_target.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from copy import deepcopy
+from typing import List, Dict
+from .generation_metric import GenerationMetric
+
+
+class PreprocessOutputTarget(GenerationMetric):
+    """
+    Preprocesses output and target texts before passing them to the base metric.
+    """
+
+    def __init__(
+        self,
+        base_metric,
+        process_output_fn,
+        process_target_fn
+    ):
+        self.base_metric = getattr(base_metric, "base_metric", base_metric)
+        self.level = base_metric.level
+        self.stats_dependencies = base_metric.stats_dependencies
+        self.process_output_fn = process_output_fn
+        self.process_target_fn = process_target_fn
+
+    def __str__(self):
+        return str(self.base_metric)
+
+    def __call__(
+        self,
+        stats: Dict[str, np.ndarray],
+        target_texts: List[str],
+        target_tokens: List[List[int]],
+    ) -> np.ndarray:
+        """
+        Applies preprocess functions to stats['greedy_texts'] and target_texts before passing them to the base metric.
+
+        Parameters:
+            stats (Dict[str, np.ndarray]): calculated stats
+            target_texts (List[str]): ground-truth texts
+            target_tokens (List[List[int]]): corresponding token splits for each target text
+        Returns:
+            np.ndarray: list of base metric values for each sample in input.
+        """
+        processed_target_texts = [self.process_target_fn(target) for target in target_texts]
+        stats = deepcopy(stats)
+        stats["greedy_texts"] = [self.process_output_fn(output) for output in stats["greedy_texts"]]
+
+        return self.base_metric(stats, processed_target_texts, target_tokens) 

--- a/src/lm_polygraph/generation_metrics/preprocess_output_target.py
+++ b/src/lm_polygraph/generation_metrics/preprocess_output_target.py
@@ -24,7 +24,6 @@ class PreprocessOutputTarget(GenerationMetric):
         self,
         stats: Dict[str, np.ndarray],
         target_texts: List[str],
-        target_tokens: List[List[int]],
     ) -> np.ndarray:
         """
         Applies preprocess functions to stats['greedy_texts'] and target_texts before passing them to the base metric.

--- a/src/lm_polygraph/generation_metrics/preprocess_output_target.py
+++ b/src/lm_polygraph/generation_metrics/preprocess_output_target.py
@@ -38,9 +38,14 @@ class PreprocessOutputTarget(GenerationMetric):
         processed_target_texts = [
             self.process_target_fn(target) for target in target_texts
         ]
-        stats = deepcopy(stats)
-        stats["greedy_texts"] = [
-            self.process_output_fn(output) for output in stats["greedy_texts"]
+
+        # Select and copy only the stats that are needed for the base metric
+        # before mutating greedy_texts with process_output_fn
+        stats_copy = {k: v for k, v in stats.items() if k in self.stats_dependencies}
+        stats_copy = deepcopy(stats_copy)
+
+        stats_copy["greedy_texts"] = [
+            self.process_output_fn(output) for output in stats_copy["greedy_texts"]
         ]
 
-        return self.base_metric(stats, processed_target_texts)
+        return self.base_metric(stats_copy, processed_target_texts)

--- a/src/lm_polygraph/generation_metrics/preprocess_output_target.py
+++ b/src/lm_polygraph/generation_metrics/preprocess_output_target.py
@@ -43,4 +43,4 @@ class PreprocessOutputTarget(GenerationMetric):
             self.process_output_fn(output) for output in stats["greedy_texts"]
         ]
 
-        return self.base_metric(stats, processed_target_texts, target_tokens)
+        return self.base_metric(stats, processed_target_texts)

--- a/src/lm_polygraph/generation_metrics/preprocess_output_target.py
+++ b/src/lm_polygraph/generation_metrics/preprocess_output_target.py
@@ -10,12 +10,7 @@ class PreprocessOutputTarget(GenerationMetric):
     Preprocesses output and target texts before passing them to the base metric.
     """
 
-    def __init__(
-        self,
-        base_metric,
-        process_output_fn,
-        process_target_fn
-    ):
+    def __init__(self, base_metric, process_output_fn, process_target_fn):
         self.base_metric = getattr(base_metric, "base_metric", base_metric)
         self.level = base_metric.level
         self.stats_dependencies = base_metric.stats_dependencies
@@ -41,8 +36,12 @@ class PreprocessOutputTarget(GenerationMetric):
         Returns:
             np.ndarray: list of base metric values for each sample in input.
         """
-        processed_target_texts = [self.process_target_fn(target) for target in target_texts]
+        processed_target_texts = [
+            self.process_target_fn(target) for target in target_texts
+        ]
         stats = deepcopy(stats)
-        stats["greedy_texts"] = [self.process_output_fn(output) for output in stats["greedy_texts"]]
+        stats["greedy_texts"] = [
+            self.process_output_fn(output) for output in stats["greedy_texts"]
+        ]
 
-        return self.base_metric(stats, processed_target_texts, target_tokens) 
+        return self.base_metric(stats, processed_target_texts, target_tokens)

--- a/src/lm_polygraph/stat_calculators/__init__.py
+++ b/src/lm_polygraph/stat_calculators/__init__.py
@@ -21,3 +21,4 @@ from .ensemble_token_data import EnsembleTokenLevelDataCalculator
 from .semantic_matrix import SemanticMatrixCalculator
 from .cross_encoder_similarity import CrossEncoderSimilarityMatrixCalculator
 from .extract_claims import ClaimsExtractor
+from .semantic_classes import SemanticClassesCalculator

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -30,7 +30,7 @@ class SemanticClassesCalculator(StatCalculator):
         model: WhiteboxModel,
         max_new_tokens: int = 100,
     ) -> Dict[str, np.ndarray]:
-        self._is_entailment = stats["semantic_matrix_classes"] == stats["entailment_id"]
+        self._is_entailment = dependencies["semantic_matrix_classes"] == dependencies["entailment_id"]
         self.get_classes(dependencies["sample_texts"])
 
         return {

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import itertools
 from collections import defaultdict
 from typing import Dict, List
 
@@ -18,10 +17,12 @@ class SemanticClassesCalculator(StatCalculator):
             [
                 "semantic_classes_entail",
             ],
-            ["sample_texts",
-             "semantic_matrix_entail",
-             "semantic_matrix_classes",
-             "entailment_id"],
+            [
+                "sample_texts",
+                "semantic_matrix_entail",
+                "semantic_matrix_classes",
+                "entailment_id"
+            ],
         )
 
     def __call__(
@@ -31,7 +32,9 @@ class SemanticClassesCalculator(StatCalculator):
         model: WhiteboxModel,
         max_new_tokens: int = 100,
     ) -> Dict[str, np.ndarray]:
-        self._is_entailment = dependencies["semantic_matrix_classes"] == dependencies["entailment_id"]
+        self._is_entailment = (
+            dependencies["semantic_matrix_classes"] == dependencies["entailment_id"]
+        )
         self.get_classes(dependencies["sample_texts"])
 
         return {

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -4,6 +4,7 @@ import itertools
 from typing import Dict, List
 
 from .stat_calculator import StatCalculator
+from lm_polygraph.utils.model import WhiteboxModel
 
 
 class SemanticClassesCalculator(StatCalculator):

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -21,7 +21,7 @@ class SemanticClassesCalculator(StatCalculator):
                 "sample_texts",
                 "semantic_matrix_entail",
                 "semantic_matrix_classes",
-                "entailment_id"
+                "entailment_id",
             ],
         )
 

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -16,7 +16,7 @@ class SemanticClassesCalculator(StatCalculator):
             [
                 "semantic_classes_entail",
             ],
-            ["blackbox_sample_texts",
+            ["sample_texts",
              "semantic_matrix_entail",
              "semantic_matrix_classes",
              "entailment_id"],
@@ -30,7 +30,7 @@ class SemanticClassesCalculator(StatCalculator):
         max_new_tokens: int = 100,
     ) -> Dict[str, np.ndarray]:
         self._is_entailment = stats["semantic_matrix_classes"] == stats["entailment_id"]
-        self.get_classes(dependencies["blackbox_sample_texts"])
+        self.get_classes(dependencies["sample_texts"])
 
         return {
             "semantic_classes_entail": {

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+import itertools
+from typing import Dict, List
+
+from .stat_calculator import StatCalculator
+
+
+class SemanticClassesCalculator(StatCalculator):
+    """
+    Paritions samples into semantic classes based on semantic matrix.
+    """
+
+    def __init__(self):
+        super().__init__(
+            [
+                "semantic_classes_entail",
+            ],
+            ["blackbox_sample_texts",
+             "semantic_matrix_entail",
+             "semantic_matrix_classes",
+             "entailment_id"],
+        )
+
+    def __call__(
+        self,
+        dependencies: Dict[str, np.array],
+        texts: List[str],
+        model: WhiteboxModel,
+        max_new_tokens: int = 100,
+    ) -> Dict[str, np.ndarray]:
+        self._is_entailment = stats["semantic_matrix_classes"] == stats["entailment_id"]
+        self.get_classes(dependencies["blackbox_sample_texts"])
+
+        return {
+            "semantic_classes_entail": {
+                "sample_to_class": self._sample_to_class,
+                "class_to_sample": self._class_to_sample,
+            }
+        }
+
+    def get_classes(self, hyps_list: List[List[str]]):
+        self._sample_to_class = {}
+        self._class_to_sample: Dict[int, List] = defaultdict(list)
+
+        [
+            self._determine_class(idx, i)
+            for idx, hyp in enumerate(hyps_list)
+            for i in range(len(hyp))
+        ]
+
+        return self._sample_to_class, self._class_to_sample
+
+    def _determine_class(self, idx: int, i: int):
+        # For first hypo just create a zeroth class
+        if i == 0:
+            self._class_to_sample[idx] = [[0]]
+            self._sample_to_class[idx] = {0: 0}
+
+            return 0
+
+        # Iterate over existing classes and return if hypo belongs to one of them
+        for class_id in range(len(self._class_to_sample[idx])):
+            class_text_id = self._class_to_sample[idx][class_id][0]
+            forward_entailment = self._is_entailment[idx, class_text_id, i]
+            backward_entailment = self._is_entailment[idx, i, class_text_id]
+            if forward_entailment and backward_entailment:
+                self._class_to_sample[idx][class_id].append(i)
+                self._sample_to_class[idx][i] = class_id
+
+                return class_id
+
+        # If none of the existing classes satisfy - create new one
+        new_class_id = len(self._class_to_sample[idx])
+        self._sample_to_class[idx][i] = new_class_id
+        self._class_to_sample[idx].append([i])
+
+        return new_class_id

--- a/src/lm_polygraph/stat_calculators/semantic_classes.py
+++ b/src/lm_polygraph/stat_calculators/semantic_classes.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import itertools
+from collections import defaultdict
 from typing import Dict, List
 
 from .stat_calculator import StatCalculator

--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -437,10 +437,10 @@ class UEManager:
             for key, val in [
                 ("input_texts", inp_texts),
                 ("target_texts", target_texts),
-                ("model", self.model),
             ]:
                 self.stats[key] += val
                 batch_stats[key] = val
+            batch_stats["model"] = self.model
 
             batch_stats["model"] = self.model
 

--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -437,6 +437,7 @@ class UEManager:
             for key, val in [
                 ("input_texts", inp_texts),
                 ("target_texts", target_texts),
+                ("model", self.model),
             ]:
                 self.stats[key] += val
                 batch_stats[key] = val
@@ -486,6 +487,7 @@ class UEManager:
                 for key, val in [
                     ("input_texts", inp_texts),
                     ("target_texts", target_texts),
+                    ("model", self.model),
                 ]:
                     batch_stats[key] = val
 

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -418,7 +418,7 @@ class WhiteboxModel(Model):
         args["return_dict_in_generate"] = True
         batch: Dict[str, torch.Tensor] = self.tokenize(input_texts)
         batch = {k: v.to(self.device()) for k, v in batch.items()}
-        sequences = self.model.generate(**batch, **args).sequences.cpu()
+        sequences = self.generate(**batch, **args).sequences.cpu()
         input_len = batch["input_ids"].shape[1]
         texts = []
 

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -192,11 +192,22 @@ class BlackboxModel(Model):
                         "Invalid prompt format. Must be either a string or a list of dictionaries."
                     )
 
-                response = openai.ChatCompletion.create(
-                    model=self.model_path,
-                    messages=messages,
-                    **args,
-                )
+                retries = 0
+                while True:
+                    try:
+                        response = openai.ChatCompletion.create(
+                            model=self.model_path,
+                            messages=messages,
+                            **args,
+                        )
+                        break
+                    except Exception as e:
+                        if retries > 4:
+                            raise Exception from e
+                        else:
+                            retries += 1
+                            continue
+
                 if args["n"] == 1:
                     texts.append(response.choices[0].message.content)
                 else:

--- a/src/lm_polygraph/utils/register_stat_calculators.py
+++ b/src/lm_polygraph/utils/register_stat_calculators.py
@@ -55,6 +55,8 @@ def register_stat_calculators(
 
     _register(InitialStateCalculator())
     _register(SemanticMatrixCalculator(nli_model=nli_model))
+    _register(SemanticClassesCalculator())
+<<<<<<< HEAD
 
     if isinstance(model, BlackboxModel):
         _register(BlackboxGreedyTextsCalculator())

--- a/src/lm_polygraph/utils/register_stat_calculators.py
+++ b/src/lm_polygraph/utils/register_stat_calculators.py
@@ -56,7 +56,6 @@ def register_stat_calculators(
     _register(InitialStateCalculator())
     _register(SemanticMatrixCalculator(nli_model=nli_model))
     _register(SemanticClassesCalculator())
-<<<<<<< HEAD
 
     if isinstance(model, BlackboxModel):
         _register(BlackboxGreedyTextsCalculator())


### PR DESCRIPTION
Adds new baseline estimators that can be used with black box instruct-finetuned models:

- LabelProb (essentialy semantic maxprob with frequency-based class probability estimation)
- SemanticEntropyEmpirical (same as usual SemEntropy but again class prob estimated based on frequence among samples)
- PTrueEmpirical (same as PTrue, but again relative frequency of `False` among samples is uncertainty)

Since paritioning samples into semantic classes is now shared dependency between SemanticEntropy and LabelProb, new stat calculator is introduced for this specific purpose.