### PR TITLE
Random baseline for claim uncertainty

### DIFF
--- a/src/lm_polygraph/estimators/__init__.py
+++ b/src/lm_polygraph/estimators/__init__.py
@@ -69,5 +69,6 @@ from .fisher_rao import FisherRao
 from .verbalized_1s import Verbalized1S
 from .verbalized_2s import Verbalized2S
 from .linguistic_1s import Linguistic1S
+from .claim.random_baseline import RandomBaselineClaim
 from .label_prob import LabelProb
 from .p_true_empirical import PTrueEmpirical

--- a/src/lm_polygraph/estimators/claim/random_baseline.py
+++ b/src/lm_polygraph/estimators/claim/random_baseline.py
@@ -7,7 +7,7 @@ from lm_polygraph.estimators.estimator import Estimator
 
 class RandomBaselineClaim(Estimator):
     """
-    Estimates the claim-level maximum token entropy.
+    Provides the claim-level random score. Useful for reporting metrics such as F1 or PR-AUC due to class inbalance.
     """
 
     def __init__(self):
@@ -22,12 +22,10 @@ class RandomBaselineClaim(Estimator):
 
         Parameters:
             stats (Dict[str, object]): input statistics, which for multiple samples includes:
-                * log p(y_i | y_<i, x) in 'greedy_log_likelihoods',
                 * list of extracted claims of type lm_polygraph.stat_calculators.extract_claims.Claim
                   in 'claims'.
         Returns:
-            List[List[float]]: concatenated minus log probabilities for each claim.
-                Higher values indicate more uncertain samples.
+            List[List[float]]: concatenated random variables.
         """
         claims = stats["claims"]
         claim_ue = []

--- a/src/lm_polygraph/estimators/claim/random_baseline.py
+++ b/src/lm_polygraph/estimators/claim/random_baseline.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from typing import Dict, List
+
+from lm_polygraph.estimators.estimator import Estimator
+
+
+class RandomBaselineClaim(Estimator):
+    """
+    Estimates the claim-level maximum token entropy.
+    """
+
+    def __init__(self):
+        super().__init__(["claims"], "claim")
+
+    def __str__(self):
+        return "RandomBaselineClaim"
+
+    def __call__(self, stats: Dict[str, object]) -> List[List[float]]:
+        """
+        Random baseline
+
+        Parameters:
+            stats (Dict[str, object]): input statistics, which for multiple samples includes:
+                * log p(y_i | y_<i, x) in 'greedy_log_likelihoods',
+                * list of extracted claims of type lm_polygraph.stat_calculators.extract_claims.Claim
+                  in 'claims'.
+        Returns:
+            List[List[float]]: concatenated minus log probabilities for each claim.
+                Higher values indicate more uncertain samples.
+        """
+        claims = stats["claims"]
+        claim_ue = []
+        for sample_claims in claims:
+            claim_ue.append([])
+            for _ in sample_claims:
+                claim_ue[-1].append(np.random.rand())
+        return claim_ue


### PR DESCRIPTION
The random baseline is useful for reporting claim level scores such as F1 or PR-AUC.