### PR TITLE
Set upper limit on spacy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ bert-score>=0.3.13
 unbabel-comet==2.2.1
 nltk>=3.7,<4
 evaluate>=0.4.2
-spacy>=3.4.0,<4
+spacy>=3.4.0,<3.8.0
 fastchat
 diskcache>=5.6.3


### PR DESCRIPTION
Spacy 3.8.0 and up depends on numpy>2.0, while COMET only works with numpy<2.0, which causes long backtracking during installation.

Pinning spacy<3.8.0 to speed up installation.