### PR TITLE
Update claim-level examples

### DIFF
--- a/examples/claim_level_example.ipynb
+++ b/examples/claim_level_example.ipynb
@@ -21,7 +21,15 @@
    "execution_count": 2,
    "id": "3b7ae864",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WhiteboxModel#from_pretrained is deprecated and will be removed in the next release. Please instantiate WhiteboxModel directly by passing an already loaded model, tokenizer and model path.\n"
+     ]
+    }
+   ],
    "source": [
     "model = WhiteboxModel.from_pretrained(\"bigscience/bloomz-560m\")"
    ]
@@ -36,7 +44,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.\n"
+      "From v4.47 onwards, when a model cache is to be returned, `generate` will return a `Cache` instance instead by default (as opposed to the legacy tuple of tuples format). If you want to keep returning the legacy format, please set `return_legacy_cache=True`.\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
      ]
     }
    ],
@@ -80,7 +92,7 @@
       "claim: He was the first person to observe something.\n",
       "aligned tokens: [22, 23, 24, 25, 26, 27, 28]\n",
       "\n",
-      "claim: What he observed was the existence of gravity.\n",
+      "claim: The thing he observed was the existence of gravity.\n",
       "aligned tokens: [22, 28, 29, 30, 31, 32]\n",
       "\n"
      ]
@@ -91,7 +103,7 @@
     "print()\n",
     "for claim in stat[\"claims\"][0]:\n",
     "    print(\"claim:\", claim.claim_text)\n",
-    "    print(\"aligned tokens:\", claim.aligned_tokens)\n",
+    "    print(\"aligned tokens:\", claim.aligned_token_ids)\n",
     "    print()"
    ]
   },
@@ -104,8 +116,7 @@
     {
      "data": {
       "text/plain": [
-       "array([9.063859 , 3.237115 , 2.468878 , 3.382793 , 7.7747087, 7.9294844],\n",
-       "      dtype=float32)"
+       "[[9.063885, 3.237104, 2.468891, 3.3827477, 7.774682, 7.9294558]]"
       ]
      },
      "execution_count": 5,
@@ -136,8 +147,12 @@
     {
      "data": {
       "text/plain": [
-       "array([-0.00411375, -0.40427966, -0.20528004, -0.12898072, -0.56441526,\n",
-       "       -0.41163102])"
+       "[[-0.004113597771295973,\n",
+       "  -0.4042782663641142,\n",
+       "  -0.20527572894879806,\n",
+       "  -0.12898275630319986,\n",
+       "  -0.5644208720670418,\n",
+       "  -0.4116346673055026]]"
       ]
      },
      "execution_count": 6,
@@ -166,9 +181,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.mlspace-calibration]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-.mlspace-calibration-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -180,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/examples/claim_level_example_ar.ipynb
+++ b/examples/claim_level_example_ar.ipynb
@@ -1239,9 +1239,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python [conda env:.mlspace-calibration]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-.mlspace-calibration-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1253,7 +1253,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/claim_level_example_ru.ipynb
+++ b/examples/claim_level_example_ru.ipynb
@@ -1219,9 +1219,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python [conda env:.mlspace-calibration]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-.mlspace-calibration-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1233,7 +1233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/claim_level_example_zh.ipynb
+++ b/examples/claim_level_example_zh.ipynb
@@ -105,6 +105,31 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "d79d1083",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[Claim(claim_text='曹操是三国时期的政治家。', sentence=' 曹操是三国时期最伟大的政治家', aligned_token_ids=[1, 2, 3, 4, 7]),\n",
+      "  Claim(claim_text='曹操是三国时期最伟大的政治家。', sentence=' 曹操是三国时期最伟大的政治家', aligned_token_ids=[1, 2, 3, 4, 5, 6, 7]),\n",
+      "  Claim(claim_text='他一生中为官。', sentence='他一生中为官，为官期间，他多次被封为侯，并多次被封为侯爵', aligned_token_ids=[9, 10, 11, 12, 13]),\n",
+      "  Claim(claim_text='他多次被封为侯。', sentence='他一生中为官，为官期间，他多次被封为侯，并多次被封为侯爵', aligned_token_ids=[9, 20, 21, 22, 23]),\n",
+      "  Claim(claim_text='他多次被封为侯爵。', sentence='他一生中为官，为官期间，他多次被封为侯，并多次被封为侯爵', aligned_token_ids=[9, 20, 21, 22, 23, 30]),\n",
+      "  Claim(claim_text='曹操一生中为官。', sentence='曹操一生中为官，为官期间，他多次被封为侯，并多次被封为侯爵', aligned_token_ids=[32, 33, 34, 35, 36]),\n",
+      "  Claim(claim_text='为官期间，曹操多次被封为侯。', sentence='曹操一生中为官，为官期间，他多次被封为侯，并多次被封为侯爵', aligned_token_ids=[32, 35, 36, 38, 39, 40, 43, 44, 45, 46]),\n",
+      "  Claim(claim_text='为官期间，曹操多次被封为侯爵。', sentence='曹操一生中为官，为官期间，他多次被封为侯，并多次被封为侯爵', aligned_token_ids=[32, 35, 36, 40, 43, 44, 45, 46, 53])]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "stat['claims']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "505008d3-3e93-4612-91f3-f90e1eab9706",
    "metadata": {},
    "outputs": [
@@ -194,7 +219,7 @@
     "print()\n",
     "for claim in stat[\"claims\"][0]:\n",
     "    print(\"claim:\", claim.claim_text)\n",
-    "    print(\"aligned tokens:\", claim.aligned_tokens)\n",
+    "    print(\"aligned tokens:\", claim.aligned_token_ids)\n",
     "    print()"
    ]
   },
@@ -474,9 +499,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.mlspace-calibration]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-.mlspace-calibration-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -488,7 +513,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- `aligned_tokens` was renamed to `align_token_ids` earlier, fixing it in notebooks
- renamed notebooks for consistency