### PR TITLE
Pytorch load hotfix, add weights_only=False in manager

### DIFF
--- a/src/lm_polygraph/utils/manager.py
+++ b/src/lm_polygraph/utils/manager.py
@@ -452,7 +452,7 @@ class UEManager:
         Parameters:
             load_path (str): Path to file with saved benchmark results to load.
         """
-        res_dict = torch.load(load_path)
+        res_dict = torch.load(load_path, weights_only=False)
 
         if available_stat_calculators is None:
             result_stat_calculators = dict()


### PR DESCRIPTION
Added hotfix for pytorch 2.6: weights_only=False in manager