### PR TITLE
Fix tokenization special symbols2

### DIFF
--- a/src/lm_polygraph/model_adapters/whitebox_model_basic.py
+++ b/src/lm_polygraph/model_adapters/whitebox_model_basic.py
@@ -1,22 +1,37 @@
 from lm_polygraph.utils.model import Model
+from lm_polygraph.utils.generation_parameters import GenerationParameters
 
-from typing import List
+from typing import List, Dict
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
+
 
 
 class WhiteboxModelBasic(Model):
     """Basic whitebox model adapter for using in stat calculators and uncertainty estimators."""
 
-    def __init__(self, model: AutoModelForCausalLM, tokenizer: AutoTokenizer):
+    def __init__(self, model: AutoModelForCausalLM, tokenizer: AutoTokenizer, 
+                 tokenizer_args: Dict, parameters: GenerationParameters = GenerationParameters(), model_type=""):
         self.model = model
         self.tokenizer = tokenizer
+        self.tokenizer_args = tokenizer_args
+        self.generation_parameters = parameters
+        self.model_type = model_type
 
     def generate(self, *args, **kwargs):
         return self.model.generate(*args, **kwargs)
 
     def tokenize(self, *args, **kwargs):
-        return self.tokenizer(*args, **kwargs)
+        return self.tokenizer(*args, **self.tokenizer_args, **kwargs)
+    
+    def device(self):
+        """
+        Returns the device the model is currently loaded on.
+
+        Returns:
+            str: device string.
+        """
+        return self.model.device
 
     def __call__(self, *args, **kwargs):
         return self.model(*args, **kwargs)

--- a/src/lm_polygraph/model_adapters/whitebox_model_basic.py
+++ b/src/lm_polygraph/model_adapters/whitebox_model_basic.py
@@ -6,12 +6,17 @@ from typing import List, Dict
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
-
 class WhiteboxModelBasic(Model):
     """Basic whitebox model adapter for using in stat calculators and uncertainty estimators."""
 
-    def __init__(self, model: AutoModelForCausalLM, tokenizer: AutoTokenizer, 
-                 tokenizer_args: Dict, parameters: GenerationParameters = GenerationParameters(), model_type=""):
+    def __init__(
+        self,
+        model: AutoModelForCausalLM,
+        tokenizer: AutoTokenizer,
+        tokenizer_args: Dict,
+        parameters: GenerationParameters = GenerationParameters(),
+        model_type="",
+    ):
         self.model = model
         self.tokenizer = tokenizer
         self.tokenizer_args = tokenizer_args
@@ -23,7 +28,7 @@ class WhiteboxModelBasic(Model):
 
     def tokenize(self, *args, **kwargs):
         return self.tokenizer(*args, **self.tokenizer_args, **kwargs)
-    
+
     def device(self):
         """
         Returns the device the model is currently loaded on.

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -550,6 +550,7 @@ class WhiteboxModel(Model):
             dict[str, torch.Tensor]: tensors dictionary obtained by tokenizing input texts batch.
         """
         # Apply chat template if tokenizer has it
+        add_start_symbol = True
         if self.tokenizer.chat_template is not None:
             formatted_texts = []
             for chat in texts:
@@ -561,7 +562,9 @@ class WhiteboxModel(Model):
                 formatted_texts.append(formatted_chat)
             texts = formatted_texts
 
-        return self.tokenizer(texts, padding=True, return_tensors="pt")
+            add_start_symbol = False
+
+        return self.tokenizer(texts, padding=True, return_tensors="pt", add_special_tokens=add_start_symbol)
 
 
 def create_ensemble(

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -564,7 +564,12 @@ class WhiteboxModel(Model):
 
             add_start_symbol = False
 
-        return self.tokenizer(texts, padding=True, return_tensors="pt", add_special_tokens=add_start_symbol)
+        return self.tokenizer(
+            texts,
+            padding=True,
+            return_tensors="pt",
+            add_special_tokens=add_start_symbol,
+        )
 
 
 def create_ensemble(


### PR DESCRIPTION
- Previously, the WhiteboxModel was adding two starting symbols \<s\> in the beginning of the generation \<s\>\<s\> in case of using apply_chat_template (one from apply_chat_template, one from tokenize).
- Fixed the implementation of WhiteboxModelBasic by adding tokenizer arguments and missing device() implementation