### PR TITLE
Add parameters for openai chat that allow using other LLM deployed vi…

### DIFF
--- a/src/lm_polygraph/generation_metrics/openai_fact_check.py
+++ b/src/lm_polygraph/generation_metrics/openai_fact_check.py
@@ -18,6 +18,7 @@ class OpenAIFactCheck(GenerationMetric):
 
     def __init__(
         self,
+        llm_url: str = None,
         openai_model: str = "gpt-4o",
         cache_path: str = os.path.expanduser("~") + "/.cache",
         language: str = "en",
@@ -29,7 +30,7 @@ class OpenAIFactCheck(GenerationMetric):
         n_threads: int = 1,
     ):
         super().__init__(["input_texts"], "claim")
-        self.openai_chat = OpenAIChat(openai_model=openai_model, cache_path=cache_path)
+        self.openai_chat = OpenAIChat(base_url=llm_url, openai_model=openai_model, cache_path=cache_path)
         self.language = language
         self.progress_bar = progress_bar
         self.fact_check_prompts = fact_check_prompts

--- a/src/lm_polygraph/generation_metrics/openai_fact_check.py
+++ b/src/lm_polygraph/generation_metrics/openai_fact_check.py
@@ -30,7 +30,9 @@ class OpenAIFactCheck(GenerationMetric):
         n_threads: int = 1,
     ):
         super().__init__(["input_texts"], "claim")
-        self.openai_chat = OpenAIChat(base_url=llm_url, openai_model=openai_model, cache_path=cache_path)
+        self.openai_chat = OpenAIChat(
+            base_url=llm_url, openai_model=openai_model, cache_path=cache_path
+        )
         self.language = language
         self.progress_bar = progress_bar
         self.fact_check_prompts = fact_check_prompts

--- a/src/lm_polygraph/utils/openai_chat.py
+++ b/src/lm_polygraph/utils/openai_chat.py
@@ -88,7 +88,7 @@ class OpenAIChat:
                 )
                 time.sleep(sleep_time)
 
-        return openai.OpenAI().chat.completions.create(
+        return openai.OpenAI(base_url=self.base_url).chat.completions.create(
             model=self.openai_model,
             messages=messages,
             temperature=0,  # for deterministic outputs

--- a/src/lm_polygraph/utils/openai_chat.py
+++ b/src/lm_polygraph/utils/openai_chat.py
@@ -16,6 +16,7 @@ class OpenAIChat:
     def __init__(
         self,
         openai_model: str = "gpt-4o",
+        base_url: str = None,
         cache_path: str = os.path.expanduser("~") + "/.cache",
     ):
         """
@@ -32,6 +33,8 @@ class OpenAIChat:
         self.cache_path = os.path.join(cache_path, "openai_chat_cache.diskcache")
         if not os.path.exists(cache_path):
             os.makedirs(cache_path)
+
+        self.base_url = base_url
 
     def ask(self, message: str) -> str:
         cache_settings = dc.DEFAULT_SETTINGS.copy()
@@ -73,7 +76,7 @@ class OpenAIChat:
         sleep_time_values = (5, 10, 30, 60, 120)
         for i in range(len(sleep_time_values)):
             try:
-                return openai.OpenAI().chat.completions.create(
+                return openai.OpenAI(base_url=self.base_url).chat.completions.create(
                     model=self.openai_model,
                     messages=messages,
                     temperature=0,  # for deterministic outputs


### PR DESCRIPTION
Now classes that depend on the openai interface can specify custom urls and access LLMs deployed as a service (e.g. via vLLM)