### PR TITLE
Calculate logarithms in MaximumTokenProbability

### DIFF
--- a/src/lm_polygraph/estimators/max_probability.py
+++ b/src/lm_polygraph/estimators/max_probability.py
@@ -59,5 +59,5 @@ class MaximumTokenProbability(Estimator):
         """
         log_likelihoods = stats["greedy_log_likelihoods"]
         return [
-            -np.exp(np.array(log_likelihood[:-1])) for log_likelihood in log_likelihoods
+            -np.array(log_likelihood[:-1]) for log_likelihood in log_likelihoods
         ]

--- a/src/lm_polygraph/estimators/max_probability.py
+++ b/src/lm_polygraph/estimators/max_probability.py
@@ -58,6 +58,4 @@ class MaximumTokenProbability(Estimator):
                 Higher values indicate more uncertain samples.
         """
         log_likelihoods = stats["greedy_log_likelihoods"]
-        return [
-            -np.array(log_likelihood[:-1]) for log_likelihood in log_likelihoods
-        ]
+        return [-np.array(log_likelihood[:-1]) for log_likelihood in log_likelihoods]


### PR DESCRIPTION
Refactor the `MaximumTokenProbability` estimator to compute logarithmic values instead of raw probabilities.

This estimator operates at token-level and is not used directly in any of the currently supported benchmarks, which evaluate at the sequence- or claim-level, so this change does not affect benchmark results.

