### PR TITLE
Fix for the chat template

### DIFF
--- a/examples/configs/polygraph_eval_mmlu.yaml
+++ b/examples/configs/polygraph_eval_mmlu.yaml
@@ -10,7 +10,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-
+instruct: false
 task: qa
 
 dataset: ['LM-Polygraph/mmlu', 'continuation']

--- a/examples/configs/polygraph_eval_person_bio_ar.yaml
+++ b/examples/configs/polygraph_eval_person_bio_ar.yaml
@@ -9,7 +9,7 @@ defaults:
   
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-
+instruct: true
 task: bio
 
 dataset: ['LM-Polygraph/person_bio', 'ar']

--- a/examples/configs/polygraph_eval_person_bio_en_jais.yaml
+++ b/examples/configs/polygraph_eval_person_bio_en_jais.yaml
@@ -9,7 +9,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-
+instruct: true
 task: bio
 
 dataset: ['LM-Polygraph/person_bio', 'en']

--- a/examples/configs/polygraph_eval_person_bio_en_mistral.yaml
+++ b/examples/configs/polygraph_eval_person_bio_en_mistral.yaml
@@ -9,7 +9,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-
+instruct: true
 task: bio
 
 dataset: ['LM-Polygraph/person_bio', 'en']

--- a/examples/configs/polygraph_eval_person_bio_ru.yaml
+++ b/examples/configs/polygraph_eval_person_bio_ru.yaml
@@ -9,7 +9,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-
+instruct: true
 task: bio
 
 dataset: ['LM-Polygraph/person_bio', 'ru']

--- a/examples/configs/polygraph_eval_person_bio_zh.yaml
+++ b/examples/configs/polygraph_eval_person_bio_zh.yaml
@@ -9,7 +9,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-
+instruct: true
 task: bio
 
 dataset: ['LM-Polygraph/person_bio', 'zh']

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -343,6 +343,7 @@ def get_whitebox_model(args, cache_kwargs={}):
             getattr(args, "generation_params", {}),
             device_map=args.model.load_model_args.device_map,
             add_bos_token=getattr(args.model, "add_bos_token", True),
+            instruct=getattr(args, "instruct", False),
             **cache_kwargs,
         )
 
@@ -360,7 +361,7 @@ def get_whitebox_model(args, cache_kwargs={}):
     generation_params = GenerationParameters(**getattr(args, "generation_params", {}))
 
     model = WhiteboxModel(
-        base_model, tokenizer, args.model.path, args.model.type, generation_params
+        base_model, tokenizer, args.model.path, args.model.type, generation_params, instruct=getattr(args, "instruct", False)
     )
 
     return model

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -398,6 +398,7 @@ class WhiteboxModel(Model):
         model_path: str = None,
         model_type: str = "CausalLM",
         generation_parameters: GenerationParameters = GenerationParameters(),
+        instruct: bool = False,
     ):
         """
         Parameters:
@@ -411,6 +412,7 @@ class WhiteboxModel(Model):
         self.model = model
         self.tokenizer = tokenizer
         self.generation_parameters = generation_parameters
+        self.instruct = instruct
 
     def _validate_args(self, args):
         """
@@ -678,7 +680,7 @@ class WhiteboxModel(Model):
         """
         # Apply chat template if tokenizer has it
         add_start_symbol = True
-        if self.tokenizer.chat_template is not None:
+        if self.instruct:
             formatted_texts = []
             for chat in texts:
                 if isinstance(chat, str):
@@ -690,7 +692,6 @@ class WhiteboxModel(Model):
             texts = formatted_texts
 
             add_start_symbol = False
-
         return self.tokenizer(
             texts,
             padding=True,


### PR DESCRIPTION
1. Standardize the configs with the parameter `instruct` (in some configs, this parameter was missing).
2. Added application of the chat template only for instruct models.