### PR TITLE
Fix/gemma attentions

### DIFF
--- a/examples/configs/model/gemma_3.py
+++ b/examples/configs/model/gemma_3.py
@@ -1,0 +1,24 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def load_model(model_path: str, device_map: str):
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path, trust_remote_code=True, device_map=device_map
+    )
+    model.config.num_hidden_layers = model.config.text_config.num_hidden_layers
+    model.config.num_attention_heads = model.config.text_config.num_attention_heads
+    model.eval()
+
+    return model
+
+
+def load_tokenizer(model_path: str, add_bos_token: bool = True):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        padding_side="left",
+        add_bos_token=add_bos_token,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    return tokenizer

--- a/examples/configs/model/gemma_3.py
+++ b/examples/configs/model/gemma_3.py
@@ -5,8 +5,10 @@ def load_model(model_path: str, device_map: str):
     model = AutoModelForCausalLM.from_pretrained(
         model_path, trust_remote_code=True, device_map=device_map
     )
-    model.config.num_hidden_layers = model.config.text_config.num_hidden_layers
-    model.config.num_attention_heads = model.config.text_config.num_attention_heads
+    if not hasattr(model.config, "num_hidden_layers"):
+        model.config.num_hidden_layers = model.config.text_config.num_hidden_layers
+    if not hasattr(model.config, "num_attention_heads"):
+        model.config.num_attention_heads = model.config.text_config.num_attention_heads
     model.eval()
 
     return model


### PR DESCRIPTION
1. Added a model loading script for Gemma-3 models that adds the parameters `num_hidden_layers` and `num_attention_heads` from `model.config.text_config` to the `model.config`. 
2. Added preprocessing of attention weight to handle diverse model output formats. This improvement addresses inconsistencies where models like Gemma return fixed-length attention weights (zero-padded to maximum sequence length) while others provide variable-length outputs per generated token.