### PR TITLE
 Deberta memory fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datasets>=2.14.2
+datasets>=2.14.2,<4.0.0
 rouge-score>=0.0.4
 nlpaug>=1.1.10
 scikit-learn>=1.5.1

--- a/src/lm_polygraph/defaults/register_default_stat_calculators.py
+++ b/src/lm_polygraph/defaults/register_default_stat_calculators.py
@@ -53,6 +53,8 @@ def register_default_stat_calculators(
         "deberta_path": deberta_model_path,
         "hf_cache": hf_cache,
         "batch_size": deberta_batch_size,
+        # allow overriding device (default: CPU or CUDA auto)
+        "device": None,
     }
 
     _register(InitialStateCalculator)

--- a/src/lm_polygraph/defaults/register_default_stat_calculators.py
+++ b/src/lm_polygraph/defaults/register_default_stat_calculators.py
@@ -48,18 +48,18 @@ def register_default_stat_calculators(
     else:
         deberta_model_path = "MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7"
 
+    # Shared NLI model config
+    nli_model_cfg = {
+        "deberta_path": deberta_model_path,
+        "hf_cache": hf_cache,
+        "batch_size": deberta_batch_size,
+    }
+
     _register(InitialStateCalculator)
     _register(
         SemanticMatrixCalculator,
         "lm_polygraph.defaults.stat_calculator_builders.default_SemanticMatrixCalculator",
-        {
-            "nli_model": {
-                "deberta_path": deberta_model_path,
-                "hf_cache": hf_cache,
-                "batch_size": deberta_batch_size,
-                "device": None,
-            }
-        },
+        {"nli_model": nli_model_cfg},
     )
     _register(SemanticClassesCalculator)
 
@@ -72,14 +72,7 @@ def register_default_stat_calculators(
             _register(
                 GreedyAlternativesNLICalculator,
                 "lm_polygraph.defaults.stat_calculator_builders.default_GreedyAlternativesNLICalculator",
-                {
-                    "nli_model": {
-                        "deberta_path": deberta_model_path,
-                        "hf_cache": hf_cache,
-                        "batch_size": deberta_batch_size,
-                        "device": None,
-                    }
-                },
+                {"nli_model": nli_model_cfg},
             )
 
     elif model_type == "Whitebox":
@@ -120,37 +113,17 @@ def register_default_stat_calculators(
         _register(
             GreedyAlternativesNLICalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_GreedyAlternativesNLICalculator",
-            {
-                "nli_model": {
-                    "deberta_path": deberta_model_path,
-                    "hf_cache": hf_cache,
-                    "batch_size": deberta_batch_size,
-                    "device": None,
-                }
-            },
+            {"nli_model": nli_model_cfg},
         )
         _register(
             GreedyAlternativesFactPrefNLICalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_GreedyAlternativesFactPrefNLICalculator",
-            {
-                "nli_model": {
-                    "deberta_path": deberta_model_path,
-                    "hf_cache": hf_cache,
-                    "batch_size": deberta_batch_size,
-                    "device": None,
-                }
-            },
+            {"nli_model": nli_model_cfg},
         )
         _register(
             SemanticClassesClaimToSamplesCalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_SemanticClassesClaimToSamplesCalculator",
-            {
-                "nli_model": {
-                    "deberta_path": deberta_model_path,
-                    "batch_size": deberta_batch_size,
-                    "device": None,
-                }
-            },
+            {"nli_model": nli_model_cfg},
         )
         _register(
             ClaimsExtractor,
@@ -191,24 +164,12 @@ def register_default_stat_calculators(
         _register(
             GreedyAlternativesNLICalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_GreedyAlternativesNLICalculator",
-            {
-                "nli_model": {
-                    "deberta_path": deberta_model_path,
-                    "batch_size": deberta_batch_size,
-                    "device": None,
-                }
-            },
+            {"nli_model": nli_model_cfg},
         )
         _register(
             GreedyAlternativesFactPrefNLICalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_GreedyAlternativesFactPrefNLICalculator",
-            {
-                "nli_model": {
-                    "deberta_path": deberta_model_path,
-                    "batch_size": deberta_batch_size,
-                    "device": None,
-                }
-            },
+            {"nli_model": nli_model_cfg},
         )
         _register(
             ClaimsExtractor,

--- a/src/lm_polygraph/defaults/register_default_stat_calculators.py
+++ b/src/lm_polygraph/defaults/register_default_stat_calculators.py
@@ -53,7 +53,6 @@ def register_default_stat_calculators(
         "deberta_path": deberta_model_path,
         "hf_cache": hf_cache,
         "batch_size": deberta_batch_size,
-        # allow overriding device (default: CPU or CUDA auto)
         "device": None,
     }
 

--- a/src/lm_polygraph/defaults/stat_calculator_builders/utils.py
+++ b/src/lm_polygraph/defaults/stat_calculator_builders/utils.py
@@ -8,14 +8,13 @@ log = logging.getLogger("lm_polygraph")
 def load_nli_model(
     deberta_path="microsoft/deberta-large-mnli",
     batch_size=10,
-    device=None,
     hf_cache: str = None,
 ):
     if deberta_path.startswith("microsoft"):
-        nli_model = Deberta(deberta_path, batch_size, device, hf_cache=hf_cache)
+        nli_model = Deberta(deberta_path, batch_size, hf_cache=hf_cache)
     else:
         nli_model = MultilingualDeberta(
-            deberta_path, batch_size, device, hf_cache=hf_cache
+            deberta_path, batch_size, hf_cache=hf_cache
         )
     log.info(
         f"Initialized {nli_model.deberta_path} on {nli_model.device} with batch_size={nli_model.batch_size}"

--- a/src/lm_polygraph/defaults/stat_calculator_builders/utils.py
+++ b/src/lm_polygraph/defaults/stat_calculator_builders/utils.py
@@ -8,13 +8,14 @@ log = logging.getLogger("lm_polygraph")
 def load_nli_model(
     deberta_path="microsoft/deberta-large-mnli",
     batch_size=10,
+    device=None,
     hf_cache: str = None,
 ):
     if deberta_path.startswith("microsoft"):
-        nli_model = Deberta(deberta_path, batch_size, hf_cache=hf_cache)
+        nli_model = Deberta(deberta_path, batch_size, device=device, hf_cache=hf_cache)
     else:
         nli_model = MultilingualDeberta(
-            deberta_path, batch_size, hf_cache=hf_cache
+            deberta_path, batch_size, device=device, hf_cache=hf_cache
         )
     log.info(
         f"Initialized {nli_model.deberta_path} on {nli_model.device} with batch_size={nli_model.batch_size}"

--- a/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
+++ b/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
@@ -22,10 +22,11 @@ def eval_nli_model(
         batch = nli_set[k : k + deberta.batch_size]
         encoded = deberta.deberta_tokenizer.batch_encode_plus(
             batch, padding=True, return_tensors="pt"
-        ).to(deberta.device)
+        )
         logits = deberta.deberta(**encoded).logits
-        logits = logits.detach().to(deberta.device)
-        for (wi, wj), prob in zip(batch, softmax(logits).cpu().detach()):
+        logits = logits.detach()
+        # apply softmax on model device, then move to CPU
+        for (wi, wj), prob in zip(batch, softmax(logits).cpu()):
             w_probs[wi][wj] = prob
 
     classes = []

--- a/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
+++ b/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 from typing import Dict, List, Tuple
 

--- a/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
+++ b/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
@@ -22,11 +22,9 @@ def eval_nli_model(
         batch = nli_set[k : k + deberta.batch_size]
         encoded = deberta.deberta_tokenizer.batch_encode_plus(
             batch, padding=True, return_tensors="pt"
-        )
-        logits = deberta.deberta(**encoded).logits
-        logits = logits.detach()
-        # apply softmax on model device, then move to CPU
-        for (wi, wj), prob in zip(batch, softmax(logits).cpu()):
+        ).to(deberta.device)
+        logits = deberta.deberta(**encoded).logits.detach().to(deberta.device)
+        for (wi, wj), prob in zip(batch, softmax(logits).cpu().detach()):
             w_probs[wi][wj] = prob
 
     classes = []

--- a/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
+++ b/src/lm_polygraph/stat_calculators/greedy_alternatives_nli.py
@@ -18,14 +18,15 @@ def eval_nli_model(
 
     softmax = nn.Softmax(dim=1)
     w_probs = defaultdict(lambda: defaultdict(lambda: None))
-    for k in range(0, len(nli_set), deberta.batch_size):
-        batch = nli_set[k : k + deberta.batch_size]
-        encoded = deberta.deberta_tokenizer.batch_encode_plus(
-            batch, padding=True, return_tensors="pt"
-        ).to(deberta.device)
-        logits = deberta.deberta(**encoded).logits.detach().to(deberta.device)
-        for (wi, wj), prob in zip(batch, softmax(logits).cpu().detach()):
-            w_probs[wi][wj] = prob
+    with torch.no_grad():
+        for k in range(0, len(nli_set), deberta.batch_size):
+            batch = nli_set[k : k + deberta.batch_size]
+            encoded = deberta.deberta_tokenizer.batch_encode_plus(
+                batch, padding=True, return_tensors="pt"
+            ).to(deberta.device)
+            logits = deberta.deberta(**encoded).logits.detach()
+            for (wi, wj), prob in zip(batch, softmax(logits).cpu()):
+                w_probs[wi][wj] = prob
 
     classes = []
     for w1, w2 in nli_queue:

--- a/src/lm_polygraph/stat_calculators/semantic_matrix.py
+++ b/src/lm_polygraph/stat_calculators/semantic_matrix.py
@@ -82,7 +82,6 @@ class SemanticMatrixCalculator(StatCalculator):
             batch_invs.append(inv)
             batch_counts.append(len(unique_texts))
 
-        device = deberta.device
         ent_id = deberta.deberta.config.label2id["ENTAILMENT"]
         contra_id = deberta.deberta.config.label2id["CONTRADICTION"]
 
@@ -104,7 +103,7 @@ class SemanticMatrixCalculator(StatCalculator):
                     batch = list(zip(first_texts, second_texts))
                     encoded = tokenizer.batch_encode_plus(
                         batch, padding=True, return_tensors="pt"
-                    ).to(device)
+                    )
                     logits = deberta.deberta(**encoded).logits.detach()
                     probs.append(softmax(logits))
                     logits_all.append(logits)

--- a/src/lm_polygraph/stat_calculators/semantic_matrix.py
+++ b/src/lm_polygraph/stat_calculators/semantic_matrix.py
@@ -82,6 +82,7 @@ class SemanticMatrixCalculator(StatCalculator):
             batch_invs.append(inv)
             batch_counts.append(len(unique_texts))
 
+        device = deberta.device
         ent_id = deberta.deberta.config.label2id["ENTAILMENT"]
         contra_id = deberta.deberta.config.label2id["CONTRADICTION"]
 
@@ -103,8 +104,8 @@ class SemanticMatrixCalculator(StatCalculator):
                     batch = list(zip(first_texts, second_texts))
                     encoded = tokenizer.batch_encode_plus(
                         batch, padding=True, return_tensors="pt"
-                    )
-                    logits = deberta.deberta(**encoded).logits.detach()
+                    ).to(device)
+                    logits = deberta.deberta(**encoded).logits.detach().to(device)
                     probs.append(softmax(logits))
                     logits_all.append(logits)
                 probs = torch.cat(probs, dim=0)

--- a/src/lm_polygraph/stat_calculators/semantic_matrix.py
+++ b/src/lm_polygraph/stat_calculators/semantic_matrix.py
@@ -89,56 +89,63 @@ class SemanticMatrixCalculator(StatCalculator):
         softmax = nn.Softmax(dim=1)
         tokenizer = deberta.deberta_tokenizer
 
-        E = []
-        C = []
-        E_logits = []
-        C_logits = []
-        P = []
+        E_tensors = []
+        C_tensors = []
+        E_logits_tensors = []
+        C_logits_tensors = []
+        P_tensors = []
 
-        for i, pairs in enumerate(batch_pairs):
-            dl = torch.utils.data.DataLoader(pairs, batch_size=deberta_batch_size)
-            probs = []
-            logits_all = []
-            for first_texts, second_texts in dl:
-                batch = list(zip(first_texts, second_texts))
-                encoded = tokenizer.batch_encode_plus(
-                    batch, padding=True, return_tensors="pt"
-                ).to(device)
-                logits = deberta.deberta(**encoded).logits.detach().to(device)
-                probs.append(softmax(logits).cpu().detach())
-                logits_all.append(logits.cpu().detach())
-            probs = torch.cat(probs, dim=0)
-            logits_all = torch.cat(logits_all, dim=0)
+        with torch.no_grad():
+            for i, pairs in enumerate(batch_pairs):
+                dl = torch.utils.data.DataLoader(pairs, batch_size=deberta_batch_size)
+                probs = []
+                logits_all = []
+                for first_texts, second_texts in dl:
+                    batch = list(zip(first_texts, second_texts))
+                    encoded = tokenizer.batch_encode_plus(
+                        batch, padding=True, return_tensors="pt"
+                    ).to(device)
+                    logits = deberta.deberta(**encoded).logits.detach()
+                    probs.append(softmax(logits))
+                    logits_all.append(logits)
+                probs = torch.cat(probs, dim=0)
+                logits_all = torch.cat(logits_all, dim=0)
 
-            entail_probs = probs[:, ent_id]
-            contra_probs = probs[:, contra_id]
-            entail_logits = logits_all[:, ent_id]
-            contra_logits = logits_all[:, contra_id]
-            class_preds = probs.argmax(-1)
+                entail_probs = probs[:, ent_id]
+                contra_probs = probs[:, contra_id]
+                entail_logits = logits_all[:, ent_id]
+                contra_logits = logits_all[:, contra_id]
+                class_preds = probs.argmax(-1)
 
-            unique_mat_shape = (batch_counts[i], batch_counts[i])
+                mat_shape = (batch_counts[i], batch_counts[i])
+                unique_E = entail_probs.view(mat_shape)
+                unique_C = contra_probs.view(mat_shape)
+                unique_E_logits = entail_logits.view(mat_shape)
+                unique_C_logits = contra_logits.view(mat_shape)
+                unique_P = class_preds.view(mat_shape)
 
-            unique_E = entail_probs.view(unique_mat_shape).numpy()
-            unique_C = contra_probs.view(unique_mat_shape).numpy()
-            unique_E_logits = entail_logits.view(unique_mat_shape).numpy()
-            unique_C_logits = contra_logits.view(unique_mat_shape).numpy()
-            unique_P = class_preds.view(unique_mat_shape).numpy()
+                inv = batch_invs[i]
+                inv_tensor = torch.as_tensor(inv, device=device)
 
-            inv = batch_invs[i]
+                # Recover full matrices by indexing with inverse indices
+                E_tensors.append(unique_E[inv_tensor, :][:, inv_tensor])
+                C_tensors.append(unique_C[inv_tensor, :][:, inv_tensor])
+                E_logits_tensors.append(unique_E_logits[inv_tensor, :][:, inv_tensor])
+                C_logits_tensors.append(unique_C_logits[inv_tensor, :][:, inv_tensor])
+                P_tensors.append(unique_P[inv_tensor, :][:, inv_tensor])
 
-            # Recover full matrices from unques by gathering along both axes
-            # using inverse index
-            E.append(unique_E[inv, :][:, inv])
-            C.append(unique_C[inv, :][:, inv])
-            E_logits.append(unique_E_logits[inv, :][:, inv])
-            C_logits.append(unique_C_logits[inv, :][:, inv])
-            P.append(unique_P[inv, :][:, inv])
+            E = torch.stack(E_tensors)
+            C = torch.stack(C_tensors)
+            E_logits = torch.stack(E_logits_tensors)
+            C_logits = torch.stack(C_logits_tensors)
+            P = torch.stack(P_tensors)
 
-        E = np.stack(E)
-        C = np.stack(C)
-        E_logits = np.stack(E_logits)
-        C_logits = np.stack(C_logits)
-        P = np.stack(P)
+        # Convert to numpy arrays on CPU at the end of computation
+        E = E.cpu().numpy()
+        C = C.cpu().numpy()
+        E_logits = E_logits.cpu().numpy()
+        C_logits = C_logits.cpu().numpy()
+        P = P.cpu().numpy()
 
         return {
             "semantic_matrix_entail": E,
@@ -146,5 +153,5 @@ class SemanticMatrixCalculator(StatCalculator):
             "semantic_matrix_entail_logits": E_logits,
             "semantic_matrix_contra_logits": C_logits,
             "semantic_matrix_classes": P,
-            "entailment_id": deberta.deberta.config.label2id["ENTAILMENT"],
+            "entailment_id": ent_id,
         }

--- a/src/lm_polygraph/stat_calculators/semantic_matrix.py
+++ b/src/lm_polygraph/stat_calculators/semantic_matrix.py
@@ -105,7 +105,7 @@ class SemanticMatrixCalculator(StatCalculator):
                     encoded = tokenizer.batch_encode_plus(
                         batch, padding=True, return_tensors="pt"
                     ).to(device)
-                    logits = deberta.deberta(**encoded).logits.detach().to(device)
+                    logits = deberta.deberta(**encoded).logits.detach()
                     probs.append(softmax(logits))
                     logits_all.append(logits)
                 probs = torch.cat(probs, dim=0)

--- a/src/lm_polygraph/stat_calculators/semantic_matrix.py
+++ b/src/lm_polygraph/stat_calculators/semantic_matrix.py
@@ -111,6 +111,10 @@ class SemanticMatrixCalculator(StatCalculator):
                 probs = torch.cat(probs, dim=0)
                 logits_all = torch.cat(logits_all, dim=0)
 
+                del encoded, logits
+
+                torch.cuda.empty_cache()
+
                 entail_probs = probs[:, ent_id]
                 contra_probs = probs[:, contra_id]
                 entail_logits = logits_all[:, ent_id]

--- a/src/lm_polygraph/utils/deberta.py
+++ b/src/lm_polygraph/utils/deberta.py
@@ -119,7 +119,8 @@ class MultilingualDeberta(Deberta):
             self.deberta_path, cache_dir=self.hf_cache
         )
         self._deberta = AutoModelForSequenceClassification.from_pretrained(
-            self.deberta_path, cache_dir=self.hf_cache,
+            self.deberta_path,
+            cache_dir=self.hf_cache,
         )
         self._deberta.to(self.device)
         self._deberta.eval()

--- a/src/lm_polygraph/utils/deberta.py
+++ b/src/lm_polygraph/utils/deberta.py
@@ -45,6 +45,14 @@ class Deberta:
 
         return self._deberta_tokenizer
 
+    @property
+    def device(self):
+        """Device on which the DeBERTa model resides."""
+        if self._deberta is None:
+            self.setup()
+        # HF models expose .device directly
+        return self._deberta.device
+
 
 
     def setup(self):

--- a/src/lm_polygraph/utils/deberta.py
+++ b/src/lm_polygraph/utils/deberta.py
@@ -25,6 +25,8 @@ class Deberta:
         ----------
         deberta_path : str
             huggingface path of the pretrained DeBERTa (default 'microsoft/deberta-large-mnli')
+        device : str
+            device on which the computations will take place (default 'cuda:0' if available, else 'cpu').
         """
         self.deberta_path = deberta_path
         self.batch_size = batch_size
@@ -51,8 +53,10 @@ class Deberta:
 
         return self._deberta_tokenizer
 
-
-
+    def to(self, device):
+        self.device = device
+        if self._deberta is not None:
+            self._deberta.to(self.device)
 
     def setup(self):
         """
@@ -91,6 +95,8 @@ class MultilingualDeberta(Deberta):
         deberta_path : str
             huggingface path of the pretrained DeBERTa (default
             'MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7')
+        device : str
+            device on which the computations will take place (default 'cuda:0' if available, else 'cpu').
         """
         self.deberta_path = deberta_path
         self.batch_size = batch_size
@@ -113,8 +119,7 @@ class MultilingualDeberta(Deberta):
             self.deberta_path, cache_dir=self.hf_cache
         )
         self._deberta = AutoModelForSequenceClassification.from_pretrained(
-            self.deberta_path,
-            cache_dir=self.hf_cache,
+            self.deberta_path, cache_dir=self.hf_cache,
         )
         self._deberta.to(self.device)
         self._deberta.eval()


### PR DESCRIPTION
Improve NLI performance and memory footprint by:

- torch.no_grad where deberta is invoked
- offload from gpu only after all processing is finished
- do memory sweeps on each iteration