### PR TITLE
Gen config fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datasets>=2.14.2
+datasets>=2.14.2,<4.0.0
 rouge-score>=0.0.4
 nlpaug>=1.1.10
 scikit-learn>=1.5.1

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -363,7 +363,7 @@ def get_whitebox_model(args, cache_kwargs={}):
 
     generation_params = GenerationParametersFactory.from_params(
         yaml_config=getattr(args, "generation_params", {}),
-        native_config=asdict(base_model.generation_config),
+        native_config=asdict(base_model.generation_config.to_dict())
     )
 
     model = WhiteboxModel(

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -22,7 +22,7 @@ from lm_polygraph.generation_metrics import *
 from lm_polygraph.estimators import *
 from lm_polygraph.ue_metrics import *
 from lm_polygraph.utils.common import load_external_module
-from lm_polygraph.utils.generation_parameters import GenerationParameters
+from lm_polygraph.utils.generation_parameters import GenerationParameters, GenerationParametersFactory
 from lm_polygraph.defaults.register_default_stat_calculators import (
     register_default_stat_calculators,
 )
@@ -360,7 +360,10 @@ def get_whitebox_model(args, cache_kwargs={}):
     load_tok_args.update(args.model.load_tokenizer_args)
     tokenizer = load_module.load_tokenizer(**load_tok_args)
 
-    generation_params = GenerationParameters(**getattr(args, "generation_params", {}))
+    generation_params = GenerationParametersFactory.from_params(
+        yaml_config=getattr(args, "generation_params", {}),
+        native_config=asdict(model.generation_config),
+    )
 
     model = WhiteboxModel(
         base_model, tokenizer, args.model.path, args.model.type, generation_params, instruct=getattr(args, "instruct", False)
@@ -378,16 +381,16 @@ def get_vllm_model(args):
     load_model_args = {'model_path': args.model.path, 
                        'max_new_tokens': args.max_new_tokens, 
                        'logprobs': args.model.logprobs}
-    
+
     load_model_args.update(args.model.load_model_args)
     base_model, sampling_params = load_module.load_model(**load_model_args)
     generation_parameters = GenerationParameters(**getattr(args, "generation_params", {}))
-    
+
     model = WhiteboxModelvLLM(model=base_model, 
                               sampling_params=sampling_params,
                               generation_parameters=generation_parameters,
                               device=args.model.device)
-    
+
     return model
 
 

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -363,7 +363,7 @@ def get_whitebox_model(args, cache_kwargs={}):
 
     generation_params = GenerationParametersFactory.from_params(
         yaml_config=getattr(args, "generation_params", {}),
-        native_config=asdict(base_model.generation_config.to_dict())
+        native_config=base_model.generation_config.to_dict()
     )
 
     model = WhiteboxModel(

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -7,6 +7,7 @@ from pathlib import Path
 from omegaconf import OmegaConf
 import uuid
 from hydra.core.hydra_config import HydraConfig
+from dataclasses import asdict
 
 import logging
 

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -363,7 +363,7 @@ def get_whitebox_model(args, cache_kwargs={}):
 
     generation_params = GenerationParametersFactory.from_params(
         yaml_config=getattr(args, "generation_params", {}),
-        native_config=asdict(model.generation_config),
+        native_config=asdict(base_model.generation_config),
     )
 
     model = WhiteboxModel(

--- a/src/lm_polygraph/utils/generation_parameters.py
+++ b/src/lm_polygraph/utils/generation_parameters.py
@@ -32,7 +32,7 @@ class GenerationParameters:
     num_beams: int = 1
     presence_penalty: float = 0.0
     repetition_penalty: float = 1.0
-    generate_until: tuple = ()
+    generate_until: list = ()
     allow_newlines: bool = True
 
 
@@ -59,8 +59,5 @@ class GenerationParametersFactory:
             # Then native model config
             elif name in native_config and native_config[name] is not None:
                 params[name] = native_config[name]
-            # Otherwise leave unset to use default
-        # Ensure generate_until is a tuple
-        if 'generate_until' in params and not isinstance(params['generate_until'], tuple):
-            params['generate_until'] = tuple(params['generate_until'])
+
         return GenerationParameters(**params)

--- a/src/lm_polygraph/utils/generation_parameters.py
+++ b/src/lm_polygraph/utils/generation_parameters.py
@@ -43,6 +43,7 @@ class GenerationParametersFactory:
 
     Priority for each parameter: yaml_config > native_config > default value.
     """
+
     @staticmethod
     def from_params(
         yaml_config: dict = None,

--- a/src/lm_polygraph/utils/generation_parameters.py
+++ b/src/lm_polygraph/utils/generation_parameters.py
@@ -34,3 +34,33 @@ class GenerationParameters:
     repetition_penalty: float = 1.0
     generate_until: tuple = ()
     allow_newlines: bool = True
+
+
+class GenerationParametersFactory:
+    """
+    Factory for creating GenerationParameters by merging YAML config,
+    model-native config, and defaults.
+
+    Priority for each parameter: yaml_config > native_config > default value.
+    """
+    @staticmethod
+    def from_params(
+        yaml_config: dict = None,
+        native_config: dict = None,
+    ) -> GenerationParameters:
+        yaml_config = yaml_config or {}
+        native_config = native_config or {}
+        params: dict = {}
+        # Iterate over dataclass fields to apply priority
+        for name, field_def in GenerationParameters.__dataclass_fields__.items():
+            # YAML config has highest priority
+            if name in yaml_config and yaml_config[name] is not None:
+                params[name] = yaml_config[name]
+            # Then native model config
+            elif name in native_config and native_config[name] is not None:
+                params[name] = native_config[name]
+            # Otherwise leave unset to use default
+        # Ensure generate_until is a tuple
+        if 'generate_until' in params and not isinstance(params['generate_until'], tuple):
+            params['generate_until'] = tuple(params['generate_until'])
+        return GenerationParameters(**params)

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -662,7 +662,7 @@ class WhiteboxModel(Model):
 
         generation_params = GenerationParametersFactory.from_params(
             yaml_config=generation_params,
-            native_config=asdict(base_model.config),
+            native_config=asdict(model.config),
         )
 
         instance = WhiteboxModel(

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -19,7 +19,7 @@ from transformers import (
     PreTrainedTokenizer,
 )
 
-from lm_polygraph.utils.generation_parameters import GenerationParameters
+from lm_polygraph.utils.generation_parameters import GenerationParameters, GenerationParametersFactory
 from lm_polygraph.utils.ensemble_utils.ensemble_generator import EnsembleGenerationMixin
 from lm_polygraph.utils.ensemble_utils.dropout import replace_dropout
 
@@ -613,7 +613,6 @@ class WhiteboxModel(Model):
         config = AutoConfig.from_pretrained(
             model_path, trust_remote_code=True, **kwargs
         )
-        generation_params = GenerationParameters(**generation_params)
 
         if any(["CausalLM" in architecture for architecture in config.architectures]):
             model_type = "CausalLM"
@@ -660,6 +659,11 @@ class WhiteboxModel(Model):
         model.eval()
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
+
+        generation_params = GenerationParametersFactory.from_params(
+            yaml_config=generation_params,
+            native_config=asdict(model.config),
+        )
 
         instance = WhiteboxModel(
             model, tokenizer, model_path, model_type, generation_params

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -662,7 +662,7 @@ class WhiteboxModel(Model):
 
         generation_params = GenerationParametersFactory.from_params(
             yaml_config=generation_params,
-            native_config=asdict(model.config),
+            native_config=asdict(base_model.config),
         )
 
         instance = WhiteboxModel(

--- a/src/lm_polygraph/utils/model.py
+++ b/src/lm_polygraph/utils/model.py
@@ -19,7 +19,10 @@ from transformers import (
     PreTrainedTokenizer,
 )
 
-from lm_polygraph.utils.generation_parameters import GenerationParameters, GenerationParametersFactory
+from lm_polygraph.utils.generation_parameters import (
+    GenerationParameters,
+    GenerationParametersFactory,
+)
 from lm_polygraph.utils.ensemble_utils.ensemble_generator import EnsembleGenerationMixin
 from lm_polygraph.utils.ensemble_utils.dropout import replace_dropout
 


### PR DESCRIPTION
Adds GenerationParametersFactory that ingests user-specified generation params and native model params, and outputs GenerationParameters object with the following priority rule: user config > model config > hard-coded defaults.

Only works for non-vLLM whitebox models, otherwise behavior is unchanged.