### PR TITLE
Fix max new tokens in estimate_uncertainty function

### DIFF
--- a/src/lm_polygraph/utils/estimate_uncertainty.py
+++ b/src/lm_polygraph/utils/estimate_uncertainty.py
@@ -95,6 +95,7 @@ def estimate_uncertainty(
         processors=[],
         ignore_exceptions=False,
         verbose=False,
+        max_new_tokens=model.generation_parameters.max_new_tokens
     )
     man()
     ue = man.estimations[estimator.level, str(estimator)]

--- a/src/lm_polygraph/utils/estimate_uncertainty.py
+++ b/src/lm_polygraph/utils/estimate_uncertainty.py
@@ -95,7 +95,7 @@ def estimate_uncertainty(
         processors=[],
         ignore_exceptions=False,
         verbose=False,
-        max_new_tokens=model.generation_parameters.max_new_tokens
+        max_new_tokens=model.generation_parameters.max_new_tokens,
     )
     man()
     ue = man.estimations[estimator.level, str(estimator)]

--- a/src/lm_polygraph/utils/generation_parameters.py
+++ b/src/lm_polygraph/utils/generation_parameters.py
@@ -34,4 +34,4 @@ class GenerationParameters:
     repetition_penalty: float = 1.0
     generate_until: tuple = ()
     allow_newlines: bool = True
-    max_new_tokens: int = 100 # Works only with estimate_uncertainty utility function
+    max_new_tokens: int = 100  # Works only with estimate_uncertainty utility function

--- a/src/lm_polygraph/utils/generation_parameters.py
+++ b/src/lm_polygraph/utils/generation_parameters.py
@@ -34,3 +34,4 @@ class GenerationParameters:
     repetition_penalty: float = 1.0
     generate_until: tuple = ()
     allow_newlines: bool = True
+    max_new_tokens: int = 100 # Works only with estimate_uncertainty utility function


### PR DESCRIPTION
Previously, it was impossible to configure max_new_tokens parameter in estimate_uncertainty function.