### PR TITLE
Added simple prompts for instruct models

### DIFF
--- a/dataset_builders/build_dataset.py
+++ b/dataset_builders/build_dataset.py
@@ -10,6 +10,8 @@ from builders.wiki import CONFIG as wiki_config
 from builders.wmt import CONFIG as wmt_config
 from builders.truthfulqa import CONFIG as truthfulqa_config
 from builders.samsum import CONFIG as samsum_config
+from builders.xsum import CONFIG as xsum_config
+from builders.gsm8k import CONFIG as gsm8k_config
 
 DATASET_CONFIG = (
     base_config
@@ -22,6 +24,8 @@ DATASET_CONFIG = (
     | wmt_config
     | truthfulqa_config
     | samsum_config
+    | xsum_config
+    | gsm8k_config
 )
 
 

--- a/dataset_builders/builders/coqa.py
+++ b/dataset_builders/builders/coqa.py
@@ -61,7 +61,7 @@ def generate_coqa_instruct_config(subset, description, few_shot_prompt):
             few_shot_prompt=few_shot_prompt,
             instruct=True,
         ),
-        "dataet": "coqa",
+        "dataset": "coqa",
         "subset": subset,
     }
 

--- a/dataset_builders/builders/coqa.py
+++ b/dataset_builders/builders/coqa.py
@@ -3,7 +3,14 @@ from functools import partial
 
 
 def prepare_coqa(
-    dataset, input_column, output_column, description, prompt, few_shot_prompt, instruct, few_shot_prompt_end
+    dataset,
+    input_column,
+    output_column,
+    description,
+    prompt,
+    few_shot_prompt,
+    instruct,
+    few_shot_prompt_end,
 ):
     def doc_to_text(doc, prompt, i=0):
         # Given a passage p, the conversation history {q1, a1, . . . qi−1, ai−1}
@@ -47,7 +54,13 @@ def prepare_coqa(
     return x, y
 
 
-def generate_coqa_instruct_config(subset, description, few_shot_prompt, end_answer="", few_shot_prompt_end="Now answer the following question in the same format."):
+def generate_coqa_instruct_config(
+    subset,
+    description,
+    few_shot_prompt,
+    end_answer="",
+    few_shot_prompt_end="Now answer the following question in the same format.",
+):
     return {
         "name": "coqa",
         "train_split": "train",
@@ -57,7 +70,7 @@ def generate_coqa_instruct_config(subset, description, few_shot_prompt, end_answ
             input_column="questions",
             output_column="answers",
             description=description,
-            prompt="Question: {question}\n"+end_answer,
+            prompt="Question: {question}\n" + end_answer,
             few_shot_prompt=few_shot_prompt,
             instruct=True,
             few_shot_prompt_end=few_shot_prompt_end,
@@ -124,6 +137,6 @@ CONFIG = {
         description="Here's a short story:\n\n{story} (End of story)\n\nAnswer the following question as briefly as possible.",
         few_shot_prompt="Question: {question}\nAnswer: {answer}",
         end_answer="Answer: {answer}",
-        few_shot_prompt_end="Now answer the following question."
+        few_shot_prompt_end="Now answer the following question.",
     ),
 }

--- a/dataset_builders/builders/coqa.py
+++ b/dataset_builders/builders/coqa.py
@@ -3,7 +3,7 @@ from functools import partial
 
 
 def prepare_coqa(
-    dataset, input_column, output_column, description, prompt, few_shot_prompt, instruct
+    dataset, input_column, output_column, description, prompt, few_shot_prompt, instruct, few_shot_prompt_end
 ):
     def doc_to_text(doc, prompt, i=0):
         # Given a passage p, the conversation history {q1, a1, . . . qi−1, ai−1}
@@ -28,7 +28,7 @@ def prepare_coqa(
                     few_shot_section = (
                         "\n\nHere are a few examples of questions and answers:"
                         + few_shot_section
-                        + "\n\nNow answer the following question in the same format.\n\n"
+                        + f"\n\n{few_shot_prompt_end}\n\n"
                     )
                 else:
                     few_shot_section = "\n\n"
@@ -47,7 +47,7 @@ def prepare_coqa(
     return x, y
 
 
-def generate_coqa_instruct_config(subset, description, few_shot_prompt):
+def generate_coqa_instruct_config(subset, description, few_shot_prompt, end_answer="", few_shot_prompt_end="Now answer the following question in the same format."):
     return {
         "name": "coqa",
         "train_split": "train",
@@ -57,9 +57,10 @@ def generate_coqa_instruct_config(subset, description, few_shot_prompt):
             input_column="questions",
             output_column="answers",
             description=description,
-            prompt="Question: {question}\n",
+            prompt="Question: {question}\n"+end_answer,
             few_shot_prompt=few_shot_prompt,
             instruct=True,
+            few_shot_prompt_end=few_shot_prompt_end,
         ),
         "dataset": "coqa",
         "subset": subset,
@@ -122,5 +123,7 @@ CONFIG = {
         subset="simple_instruct",
         description="Here's a short story:\n\n{story} (End of story)\n\nAnswer the following question as briefly as possible.",
         few_shot_prompt="Question: {question}\nAnswer: {answer}",
+        end_answer="Answer: {answer}",
+        few_shot_prompt_end="Now answer the following question."
     ),
 }

--- a/dataset_builders/builders/coqa.py
+++ b/dataset_builders/builders/coqa.py
@@ -118,4 +118,9 @@ CONFIG = {
         description="Here's a short story:\n\n{story} (End of story)\n\nProvide your {topk} best guesses for the following question. Give ONLY the guesses, no other words or explanation. For example:\n\nG1: <first most likely guess, as short as possible; not a complete sentence, just the guess!>\n...\nG{topk}: <{topk}-th most likely guess, as short as possible; not a complete sentence, just the guess!>",
         few_shot_prompt="Question: {question}\nG1: {answer}\n...\nG{topk}: <other guess>",
     ),
+    "coqa_simple_instruct": generate_coqa_instruct_config(
+        subset="simple_instruct",
+        description="Here's a short story:\n\n{story} (End of story)\n\nAnswer the following question as briefly as possible.",
+        few_shot_prompt="Question: {question}\nAnswer: {answer}",
+    ),
 }

--- a/dataset_builders/builders/gsm8k.py
+++ b/dataset_builders/builders/gsm8k.py
@@ -1,0 +1,69 @@
+from functools import partial
+
+base_few_shot_prompt_gsm8k = """Q: There are 15 trees in the grove. Grove workers will plant trees in the grove today. After they are done, there will be 21 trees. How many trees did the grove workers plant today?
+A: There are 15 trees originally. Then there were 21 trees after some more were planted. So there must have been 21 - 15 = 6. The answer is 6.
+
+Q: If there are 3 cars in the parking lot and 2 more cars arrive, how many cars are in the parking lot?
+A: There are originally 3 cars. 2 more cars arrive. 3 + 2 = 5. The answer is 5.
+
+Q: Leah had 32 chocolates and her sister had 42. If they ate 35, how many pieces do they have left in total?
+A: Originally, Leah had 32 chocolates. Her sister had 42. So in total they had 32 + 42 = 74. After eating 35, they had 74 - 35 = 39. The answer is 39.
+
+Q: Jason had 20 lollipops. He gave Denny some lollipops. Now Jason has 12 lollipops. How many lollipops did Jason give to Denny?
+A: Jason started with 20 lollipops. Then he had 12 after giving some to Denny. So he gave Denny 20 - 12 = 8. The answer is 8.
+
+Q: Shawn has five toys. For Christmas, he got two toys each from his mom and dad. How many toys does he have now?
+A: Shawn started with 5 toys. If he got 2 toys each from his mom and dad, then that is 4 more toys. 5 + 4 = 9. The answer is 9.
+
+Q: There were nine computers in the server room. Five more computers were installed each day, from monday to thursday. How many computers are now in the server room?
+A: There were originally 9 computers. For each of 4 days, 5 more computers were added. So 5 * 4 = 20 computers were added. 9 + 20 is 29. The answer is 29.
+
+Q: Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many golf balls did he have at the end of wednesday?
+A: Michael started with 58 golf balls. After losing 23 on tuesday, he had 58 - 23 = 35. After losing 2 more, he had 35 - 2 = 33 golf balls. The answer is 33.
+
+Q: Olivia has $23. She bought five bagels for $3 each. How much money does she have left?
+A: Olivia had 23 dollars. 5 bagels for 3 dollars each will be 5 x 3 = 15 dollars. So she has 23 - 15 dollars left. 23 - 15 is 8. The answer is 8."""
+
+instruct_few_shot_prompt_gsm8k = base_few_shot_prompt_gsm8k.replace(
+    "Q:", "Question:"
+).replace("A:", "Answer:")
+
+
+def prepare_gsm8k(
+    dataset,
+    prompt,
+    few_shot_prompt,
+):
+    x, y = [], []
+    for inst in dataset:
+        x.append(few_shot_prompt + prompt.format(question=inst["question"]))
+        y.append(inst["answer"])
+    return x, y
+
+
+CONFIG = {
+    "gsm8k": {
+        "name": ["gsm8k", "main"],
+        "train_split": "train",
+        "test_split": "test",
+        "prepare_func": partial(
+            prepare_gsm8k,
+            prompt="\n\nQ: {question}\nA:",
+            few_shot_prompt=base_few_shot_prompt_gsm8k,
+        ),
+        "dataset": "truthfulqa",
+        "subset": "continuation",
+    },
+    "gsm8k_simple_instruct": {
+        "name": ["gsm8k", "main"],
+        "train_split": "train",
+        "test_split": "test",
+        "prepare_func": partial(
+            prepare_gsm8k,
+            prompt="\n\nQuestion: {question}\nAnswer:",
+            few_shot_prompt=f'Given the following question, reason and give a final answer to the question. Your response should end with "The answer is [answer]" where [answer] is the response to the question.\n\nHere are a few examples of questions and answers:\n\n{instruct_few_shot_prompt_gsm8k}\n\nNow answer the following question.',
+        ),
+        "dataset": "gsm8k",
+        "subset": "simple_instruct",
+    },
+}

--- a/dataset_builders/builders/gsm8k.py
+++ b/dataset_builders/builders/gsm8k.py
@@ -51,7 +51,7 @@ CONFIG = {
             prompt="\n\nQ: {question}\nA:",
             few_shot_prompt=base_few_shot_prompt_gsm8k,
         ),
-        "dataset": "truthfulqa",
+        "dataset": "gsm8k",
         "subset": "continuation",
     },
     "gsm8k_simple_instruct": {

--- a/dataset_builders/builders/mmlu.py
+++ b/dataset_builders/builders/mmlu.py
@@ -91,7 +91,7 @@ def prepare_mmlu(
     return x, y
 
 
-def generate_mmlu_instruct_config(description, few_shot_prompt, subset):
+def generate_mmlu_instruct_config(description, few_shot_prompt, subset, end_answer=""):
     return {
         "name": ["cais/mmlu", "all"],
         "train_split": "validation",
@@ -99,7 +99,8 @@ def generate_mmlu_instruct_config(description, few_shot_prompt, subset):
         "prepare_func": partial(
             prepare_mmlu,
             output_column="answer",
-            prompt="Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n",
+            prompt="Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\n"
+            + end_answer,
             description=description,
             mmlu_max_subject_size=100,
             n_shot=5,
@@ -174,5 +175,6 @@ CONFIG = {
         description="Given the following question about {subject} and four candidate answers (A, B, C, and D), choose the best answer. Your response should contain only the selected option's letter (A, B, C, or D), not a complete sentence.",
         few_shot_prompt="Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nAnswer:{answer}",
         subset="simple_instruct",
+        end_answer="Answer:{answer}",
     ),
 }

--- a/dataset_builders/builders/mmlu.py
+++ b/dataset_builders/builders/mmlu.py
@@ -170,4 +170,9 @@ CONFIG = {
         few_shot_prompt="Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nG1: {answer}\n...\nG{topk}: <other guess>",
         subset="verb_2s_topk",
     ),
+    "mmlu_simple_instruct": generate_mmlu_instruct_config(
+        description="Given the following question about {subject} and four candidate answers (A, B, C, and D), choose the best answer. Your response should contain only the selected option's letter (A, B, C, or D), not a complete sentence.",
+        few_shot_prompt="Q:{question}\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}\nAnswer:{answer}",
+        subset="simple_instruct",
+    ),
 }

--- a/dataset_builders/builders/samsum.py
+++ b/dataset_builders/builders/samsum.py
@@ -24,4 +24,15 @@ CONFIG = {
         "dataset": "samsum",
         "subset": "continuation",
     },
+    "samsum_simple_instruct": {
+        "name": "samsum",
+        "train_split": "train",
+        "test_split": "test",
+        "prepare_func": partial(
+            prepare_samsum,
+            prompt="Provide a summary for the following dialogue. The summary should (1) be rather short, (2) extract important pieces of information, (3) include names of interlocutors, (4) be written in the third person.\n\nHere's the dialogue:\n\n{text} (End of dialogue).\n\nSummary:\n",
+        ),
+        "dataset": "samsum",
+        "subset": "simple_instruct",
+    },
 }

--- a/dataset_builders/builders/trivia_qa.py
+++ b/dataset_builders/builders/trivia_qa.py
@@ -42,9 +42,7 @@ def prepare_trivia_qa(
                     )
                     + "\n\n"
                 )
-            formatted_few_shot_prompt += (
-                f"{few_shot_prompt_end}:\n\n"
-            )
+            formatted_few_shot_prompt += f"{few_shot_prompt_end}:\n\n"
         else:
             formatted_few_shot_prompt = ""
             for inst in few_shot_data:
@@ -72,14 +70,20 @@ def prepare_trivia_qa(
     return x, y
 
 
-def generate_triviaqa_instruct_config(description, few_shot_prompt, subset, end_answer="", few_shot_prompt_end="Now answer the following question in the same format:"):
+def generate_triviaqa_instruct_config(
+    description,
+    few_shot_prompt,
+    subset,
+    end_answer="",
+    few_shot_prompt_end="Now answer the following question in the same format:",
+):
     return {
         "name": ["trivia_qa", "rc.nocontext"],
         "train_split": "train",
         "test_split": "validation",
         "prepare_func": partial(
             prepare_trivia_qa,
-            prompt="Question: {question}\n"+end_answer,
+            prompt="Question: {question}\n" + end_answer,
             n_shot=5,
             few_shot_dataset_func=partial(
                 datasets.load_dataset,
@@ -159,6 +163,6 @@ CONFIG = {
         few_shot_prompt="Question: {question}\nAnswer: {answer}",
         subset="simple_instruct",
         end_answer="Answer: ",
-        few_shot_prompt_end="Now answer the following question:"
+        few_shot_prompt_end="Now answer the following question:",
     ),
 }

--- a/dataset_builders/builders/trivia_qa.py
+++ b/dataset_builders/builders/trivia_qa.py
@@ -13,6 +13,7 @@ def prepare_trivia_qa(
     description,
     few_shot_prompt,
     instruct,
+    few_shot_prompt_end,
 ):
     import numpy as np
 
@@ -42,7 +43,7 @@ def prepare_trivia_qa(
                     + "\n\n"
                 )
             formatted_few_shot_prompt += (
-                "Now answer the following question in the same format:\n\n"
+                f"{few_shot_prompt_end}:\n\n"
             )
         else:
             formatted_few_shot_prompt = ""
@@ -71,14 +72,14 @@ def prepare_trivia_qa(
     return x, y
 
 
-def generate_triviaqa_instruct_config(description, few_shot_prompt, subset):
+def generate_triviaqa_instruct_config(description, few_shot_prompt, subset, end_answer="", few_shot_prompt_end="Now answer the following question in the same format:"):
     return {
         "name": ["trivia_qa", "rc.nocontext"],
         "train_split": "train",
         "test_split": "validation",
         "prepare_func": partial(
             prepare_trivia_qa,
-            prompt="Question: {question}\n",
+            prompt="Question: {question}\n"+end_answer,
             n_shot=5,
             few_shot_dataset_func=partial(
                 datasets.load_dataset,
@@ -89,6 +90,7 @@ def generate_triviaqa_instruct_config(description, few_shot_prompt, subset):
             description=description,
             few_shot_prompt=few_shot_prompt,
             instruct=True,
+            few_shot_prompt_end=few_shot_prompt_end,
         ),
         "dataset": "triviaqa",
         "subset": subset,
@@ -156,5 +158,7 @@ CONFIG = {
         description="Answer the following question as briefly as possible.",
         few_shot_prompt="Question: {question}\nAnswer: {answer}",
         subset="simple_instruct",
+        end_answer="Answer: ",
+        few_shot_prompt_end="Now answer the following question:"
     ),
 }

--- a/dataset_builders/builders/trivia_qa.py
+++ b/dataset_builders/builders/trivia_qa.py
@@ -152,4 +152,9 @@ CONFIG = {
         few_shot_prompt="Question: {question}\nG1: {answer}\n...\nG{topk}: <other guess>",
         subset="verb_2s_topk",
     ),
+    "triviaqa_simple_instruct": generate_triviaqa_instruct_config(
+        description="Answer the following question as briefly as possible.",
+        few_shot_prompt="Question: {question}\nAnswer: {answer}",
+        subset="simple_instruct",
+    ),
 }

--- a/dataset_builders/builders/truthfulqa.py
+++ b/dataset_builders/builders/truthfulqa.py
@@ -25,4 +25,15 @@ CONFIG = {
         "dataset": "truthfulqa",
         "subset": "continuation",
     },
+    "truthfulqa_simple_instruct": {
+        "name": ["truthful_qa", "generation"],
+        "test_split": "validation",
+        "prepare_func": partial(
+            prepare_truthfulqa,
+            prompt="\n\nQuestion: {question}\nAnswer:",
+            few_shot_prompt='Answer the following question clearly and concisely. Respond with "I have no comment" only if the question is nonsensical, irrelevant, or cannot be reasonably answered.\n\nHere are a few examples of questions and answers:\n\nQuestion: What is human life expectancy in the United States?\nAnswer: Human life expectancy in the United States is 78 years.\n\nQuestion: Who was president of the United States in 1955?\nAnswer: Dwight D. Eisenhower was president of the United States in 1955.\n\nQuestion: Which party did he belong to?\nAnswer: He belonged to the Republican Party.\n\nQuestion: How does a telescope work?\nAnswer: Telescopes use lenses or mirrors to focus light and make objects appear closer.\n\nQuestion: Where were the 1992 Olympics held?\nAnswer: The 1992 Olympics were held in Barcelona, Spain.\n\nNow answer the following question.',
+        ),
+        "dataset": "truthfulqa",
+        "subset": "simple_instruct",
+    },
 }

--- a/dataset_builders/builders/wmt.py
+++ b/dataset_builders/builders/wmt.py
@@ -48,6 +48,19 @@ CONFIG = {
         "dataset": "wmt14",
         "subset": "fren",
     },
+    "wmt14_fren_simple_instruct": {
+        "name": ["wmt14", "fr-en"],
+        "train_split": "train",
+        "test_split": "test",
+        "prepare_func": partial(
+            prepare_wmt,
+            input_column="fr",
+            output_column="en",
+            prompt="Translate the following {source_lang} text into {target_lang}, give only the translation.\n\nOriginal:\n{text}\nTranslation:\n",
+        ),
+        "dataset": "wmt14",
+        "subset": "fren_simple_instruct",
+    },
     "wmt19_deen": {
         "name": ["wmt19", "de-en"],
         "train_split": "train",
@@ -61,6 +74,19 @@ CONFIG = {
         "dataset": "wmt19",
         "subset": "deen",
     },
+    "wmt19_deen_simple_instruct": {
+        "name": ["wmt19", "de-en"],
+        "train_split": "train",
+        "test_split": "validation",
+        "prepare_func": partial(
+            prepare_wmt,
+            input_column="de",
+            output_column="en",
+            prompt="Translate the following {source_lang} text into {target_lang}, give only the translation.\n\nOriginal:\n{text}\nTranslation:\n",
+        ),
+        "dataset": "wmt19",
+        "subset": "deen_simple_instruct",
+    },
     "wmt19_ruen": {
         "name": ["wmt19", "ru-en"],
         "train_split": "train",
@@ -73,5 +99,18 @@ CONFIG = {
         ),
         "dataset": "wmt19",
         "subset": "ruen",
+    },
+    "wmt19_ruen_simple_instruct": {
+        "name": ["wmt19", "ru-en"],
+        "train_split": "train",
+        "test_split": "validation",
+        "prepare_func": partial(
+            prepare_wmt,
+            input_column="ru",
+            output_column="en",
+            prompt="Translate the following {source_lang} text into {target_lang}, give only the translation.\n\nOriginal:\n{text}\nTranslation:\n",
+        ),
+        "dataset": "wmt19",
+        "subset": "ruen_simple_instruct",
     },
 }

--- a/dataset_builders/builders/xsum.py
+++ b/dataset_builders/builders/xsum.py
@@ -1,0 +1,38 @@
+from functools import partial
+
+
+def prepare_xsum(
+    dataset,
+    prompt,
+):
+    x, y = [], []
+    for inst in dataset:
+        x.append(prompt.format(text=inst["document"]))
+        y.append(inst["summary"])
+    return x, y
+
+
+CONFIG = {
+    "xsum": {
+        "name": "xsum",
+        "train_split": "train",
+        "test_split": "test",
+        "prepare_func": partial(
+            prepare_xsum,
+            prompt="Here's the text and it's short one-sentence summary.\n\nText:\n{text}\n\nSummary (one sentence):",
+        ),
+        "dataset": "xsum",
+        "subset": "continuation",
+    },
+    "xsum_simple_instruct": {
+        "name": "xsum",
+        "train_split": "train",
+        "test_split": "test",
+        "prepare_func": partial(
+            prepare_xsum,
+            prompt="Provide a short one-sentence summary of no more than 60 words for the following text.\n\nHere's the text:\n{text} (End of text).\n\nSummary:\n",
+        ),
+        "dataset": "xsum",
+        "subset": "simple_instruct",
+    },
+}

--- a/dataset_builders/builders/xsum.py
+++ b/dataset_builders/builders/xsum.py
@@ -30,7 +30,7 @@ CONFIG = {
         "test_split": "test",
         "prepare_func": partial(
             prepare_xsum,
-            prompt="Provide a short one-sentence summary of no more than 60 words for the following text.\n\nHere's the text:\n{text} (End of text).\n\nSummary:\n",
+            prompt="Provide a short one-sentence summary for the following text.\n\nHere's the text:\n{text} (End of text).\n\nSummary:\n",
         ),
         "dataset": "xsum",
         "subset": "simple_instruct",

--- a/dataset_builders/manager.py
+++ b/dataset_builders/manager.py
@@ -93,7 +93,6 @@ def main():
         print(
             "WARNING: --publish and --save-to-disk are not specified, so dataset will not be stored anywhere"
         )
-
     dataset = build_dataset(args.dataset)
     if args.save_to_disk:
         dataset.save_to_disk(pathlib.Path("result") / args.dataset)

--- a/examples/configs/estimators/default_estimators.yaml
+++ b/examples/configs/estimators/default_estimators.yaml
@@ -62,28 +62,28 @@
 - name: LUQ
 - name: KernelLanguageEntropy
 - name: EigenScore
-- name: RenyiNeg
-- name: FisherRao
-- name: MahalanobisDistanceSeq
-- name: RelativeMahalanobisDistanceSeq
-- name: RDESeq
-- name: PPLMDSeq
-  cfg:
-    md_type: "MD"
-- name: PPLMDSeq
-  cfg:
-    md_type: "RMD"
-- name: Focus
-  cfg:
-    model_name: '${model.path}'
-    path: "${cache_path}/focus/${model.path}/token_idf.pkl"
-    gamma: 0.9
-    p: 0.01
-    idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
-    trust_remote_code: True
-    idf_seed: 42
-    idf_dataset_size: -1
-    spacy_path: "en_core_web_sm"
+# - name: RenyiNeg
+# - name: FisherRao
+# - name: MahalanobisDistanceSeq
+# - name: RelativeMahalanobisDistanceSeq
+# - name: RDESeq
+# - name: PPLMDSeq
+#   cfg:
+#     md_type: "MD"
+# - name: PPLMDSeq
+#   cfg:
+#     md_type: "RMD"
+# - name: Focus
+#   cfg:
+#     model_name: '${model.path}'
+#     path: "${cache_path}/focus/${model.path}/token_idf.pkl"
+#     gamma: 0.9
+#     p: 0.01
+#     idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
+#     trust_remote_code: True
+#     idf_seed: 42
+#     idf_dataset_size: -1
+#     spacy_path: "en_core_web_sm"
 - name: AttentionScore
   cfg:
     layer: 16

--- a/examples/configs/estimators/default_estimators.yaml
+++ b/examples/configs/estimators/default_estimators.yaml
@@ -62,28 +62,28 @@
 - name: LUQ
 - name: KernelLanguageEntropy
 - name: EigenScore
-# - name: RenyiNeg
-# - name: FisherRao
-# - name: MahalanobisDistanceSeq
-# - name: RelativeMahalanobisDistanceSeq
-# - name: RDESeq
-# - name: PPLMDSeq
-#   cfg:
-#     md_type: "MD"
-# - name: PPLMDSeq
-#   cfg:
-#     md_type: "RMD"
-# - name: Focus
-#   cfg:
-#     model_name: '${model.path}'
-#     path: "${cache_path}/focus/${model.path}/token_idf.pkl"
-#     gamma: 0.9
-#     p: 0.01
-#     idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
-#     trust_remote_code: True
-#     idf_seed: 42
-#     idf_dataset_size: -1
-#     spacy_path: "en_core_web_sm"
+- name: RenyiNeg
+- name: FisherRao
+- name: MahalanobisDistanceSeq
+- name: RelativeMahalanobisDistanceSeq
+- name: RDESeq
+- name: PPLMDSeq
+  cfg:
+    md_type: "MD"
+- name: PPLMDSeq
+  cfg:
+    md_type: "RMD"
+- name: Focus
+  cfg:
+    model_name: '${model.path}'
+    path: "${cache_path}/focus/${model.path}/token_idf.pkl"
+    gamma: 0.9
+    p: 0.01
+    idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
+    trust_remote_code: True
+    idf_seed: 42
+    idf_dataset_size: -1
+    spacy_path: "en_core_web_sm"
 - name: AttentionScore
   cfg:
     layer: 16

--- a/examples/configs/instruct/model/default_causal.py
+++ b/examples/configs/instruct/model/default_causal.py
@@ -3,7 +3,10 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 def load_model(model_path: str, device_map: str):
     model = AutoModelForCausalLM.from_pretrained(
-        model_path, trust_remote_code=True, device_map=device_map
+        model_path,
+        trust_remote_code=True,
+        device_map=device_map,
+        attn_implementation="eager",
     )
     model.eval()
 

--- a/examples/configs/model/default_causal.py
+++ b/examples/configs/model/default_causal.py
@@ -3,7 +3,10 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 def load_model(model_path: str, device_map: str):
     model = AutoModelForCausalLM.from_pretrained(
-        model_path, trust_remote_code=True, device_map=device_map, attn_implementation="eager",
+        model_path,
+        trust_remote_code=True,
+        device_map=device_map,
+        attn_implementation="eager",
     )
     model.eval()
 

--- a/examples/configs/model/default_causal.py
+++ b/examples/configs/model/default_causal.py
@@ -3,7 +3,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 def load_model(model_path: str, device_map: str):
     model = AutoModelForCausalLM.from_pretrained(
-        model_path, trust_remote_code=True, device_map=device_map
+        model_path, trust_remote_code=True, device_map=device_map, attn_implementation="eager",
     )
     model.eval()
 

--- a/examples/configs/model/gemma_3.py
+++ b/examples/configs/model/gemma_3.py
@@ -3,7 +3,10 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 def load_model(model_path: str, device_map: str):
     model = AutoModelForCausalLM.from_pretrained(
-        model_path, trust_remote_code=True, device_map=device_map
+        model_path,
+        trust_remote_code=True,
+        device_map=device_map,
+        attn_implementation="eager",
     )
     if not hasattr(model.config, "num_hidden_layers"):
         model.config.num_hidden_layers = model.config.text_config.num_hidden_layers

--- a/examples/configs/polygraph_eval_coqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_coqa_simple_instruct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model.path}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - base_processing_coqa
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+task: qa
+instruct: true
+
+dataset: ['LM-polygraph/coqa', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+n_shot: 0
+few_shot_split: train
+few_shot_prompt: null
+trust_remote_code: false
+size: null
+
+max_new_tokens: 20
+load_from_disk: false
+generation_params:
+  generate_until:
+    - "\n"
+subsample_eval_dataset: -1
+batch_size: 1
+
+generation_metrics: null
+ignore_exceptions: false
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_gsm8k_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_gsm8k_simple_instruct.yaml
@@ -10,7 +10,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-instruct: false
+instruct: true
 task: qa
 
 dataset: ['LM-Polygraph/gsm8k', 'simple_instruct']

--- a/examples/configs/polygraph_eval_gsm8k_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_gsm8k_simple_instruct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['LM-Polygraph/gsm8k', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 256
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+
+target_ignore_regex: "(?s).*#### "
+output_ignore_regex: "(?s).*The answer is "
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_mmlu_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_mmlu_simple_instruct.yaml
@@ -1,0 +1,37 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['LM-Polygraph/mmlu', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 3
+load_from_disk: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_mmlu_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_mmlu_simple_instruct.yaml
@@ -10,7 +10,8 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-instruct: false
+instruct: true
+normalize: true
 task: qa
 
 dataset: ['LM-Polygraph/mmlu', 'simple_instruct']

--- a/examples/configs/polygraph_eval_samsum_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_samsum_simple_instruct.yaml
@@ -12,7 +12,7 @@ cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
 
 device: cpu
-instruct: false
+instruct: true
 task: ats
 
 dataset: ['LM-Polygraph/samsum', 'simple_instruct']
@@ -25,7 +25,7 @@ load_from_disk: false
 trust_remote_code: true
 size: 10000
 
-source_ignore_regex: "(?s).*Dialogue:\n(.*?)\n\nSummary"
+source_ignore_regex: "(?s).*Here's the dialogue:\n(.*?)\n\nSummary"
 
 subsample_eval_dataset: -1
 

--- a/examples/configs/polygraph_eval_samsum_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_samsum_simple_instruct.yaml
@@ -1,0 +1,39 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model.path}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+device: cpu
+instruct: false
+task: ats
+
+dataset: ['LM-Polygraph/samsum', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 128
+load_from_disk: false
+trust_remote_code: true
+size: 10000
+
+source_ignore_regex: "(?s).*Dialogue:\n(.*?)\n\nSummary"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_triviaqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_triviaqa_simple_instruct.yaml
@@ -11,7 +11,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-instruct: false
+instruct: true
 task: qa
 
 dataset: ['LM-Polygraph/triviaqa', 'simple_instruct']

--- a/examples/configs/polygraph_eval_triviaqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_triviaqa_simple_instruct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - base_processing_triviaqa
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['LM-Polygraph/triviaqa', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 20
+load_from_disk: false
+multiref: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 2
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_truthfulqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_truthfulqa_simple_instruct.yaml
@@ -1,0 +1,36 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['LM-Polygraph/truthfulqa', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 128
+load_from_disk: false
+multiref: true
+trust_remote_code: false
+size: 10000
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 2
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_truthfulqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_truthfulqa_simple_instruct.yaml
@@ -10,7 +10,7 @@ defaults:
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
-instruct: false
+instruct: true
 task: qa
 
 dataset: ['LM-Polygraph/truthfulqa', 'simple_instruct']

--- a/examples/configs/polygraph_eval_wmt14_deen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt14_deen_simple_instruct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model.path}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+device: cpu
+instruct: false
+task: nmt
+
+dataset: ['LM-Polygraph/wmt14', 'deen_simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 107
+load_from_disk: false
+trust_remote_code: false
+size: 10000
+
+source_ignore_regex: "(?s).*Original:\n(.*?)\nTranslation:\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1
+    

--- a/examples/configs/polygraph_eval_wmt14_fren_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt14_fren_simple_instruct.yaml
@@ -12,10 +12,10 @@ cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
 
 device: cpu
-instruct: false
+instruct: true
 task: nmt
 
-dataset: ['LM-Polygraph/wmt14', 'deen_simple_instruct']
+dataset: ['LM-Polygraph/wmt14', 'fren_simple_instruct']
 text_column: input
 label_column: output
 train_split: train

--- a/examples/configs/polygraph_eval_wmt19_deen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt19_deen_simple_instruct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model.path}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+device: cpu
+instruct: false
+task: nmt
+
+dataset: ['LM-Polygraph/wmt19', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 107
+load_from_disk: false
+trust_remote_code: false
+size: 10000
+
+source_ignore_regex: "(?s).*Original:\n(.*?)\nTranslation:\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1
+    

--- a/examples/configs/polygraph_eval_wmt19_deen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt19_deen_simple_instruct.yaml
@@ -12,10 +12,10 @@ cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
 
 device: cpu
-instruct: false
+instruct: true
 task: nmt
 
-dataset: ['LM-Polygraph/wmt19', 'simple_instruct']
+dataset: ['LM-Polygraph/wmt19', 'deen_simple_instruct']
 text_column: input
 label_column: output
 train_split: train

--- a/examples/configs/polygraph_eval_wmt19_ruen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt19_ruen_simple_instruct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model.path}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+device: cpu
+instruct: false
+task: nmt
+
+dataset: ['LM-Polygraph/wmt19', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 107
+load_from_disk: false
+trust_remote_code: false
+size: 10000
+
+source_ignore_regex: "(?s).*Original:\n(.*?)\nTranslation:\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1
+    

--- a/examples/configs/polygraph_eval_wmt19_ruen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt19_ruen_simple_instruct.yaml
@@ -12,10 +12,10 @@ cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
 
 device: cpu
-instruct: false
+instruct: true
 task: nmt
 
-dataset: ['LM-Polygraph/wmt19', 'simple_instruct']
+dataset: ['LM-Polygraph/wmt19', 'ruen_simple_instruct']
 text_column: input
 label_column: output
 train_split: train

--- a/examples/configs/polygraph_eval_xsum_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_xsum_simple_instruct.yaml
@@ -12,7 +12,7 @@ cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
 
 device: cpu
-instruct: false
+instruct: true
 task: ats
 
 dataset: ['LM-Polygraph/xsum', 'simple_instruct']
@@ -25,7 +25,7 @@ load_from_disk: false
 trust_remote_code: true
 size: 10000
 
-source_ignore_regex: "(?s).*Text:\n(.*?)\n\nSummary"
+source_ignore_regex: "(?s).*Here's the text:\n(.*?)\n\nSummary"
 
 subsample_eval_dataset: -1
 

--- a/examples/configs/polygraph_eval_xsum_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_xsum_simple_instruct.yaml
@@ -1,0 +1,39 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model.path}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: default_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+
+device: cpu
+instruct: false
+task: ats
+
+dataset: ['LM-Polygraph/xsum', 'simple_instruct']
+text_column: input
+label_column: output
+train_split: train
+eval_split: test
+max_new_tokens: 56
+load_from_disk: false
+trust_remote_code: true
+size: 10000
+
+source_ignore_regex: "(?s).*Text:\n(.*?)\n\nSummary"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1


### PR DESCRIPTION
Added simplified prompts for instruction-tuned models. The main motivation for using simplified prompts is that overly strict instructions tend to make models overconfident, which negatively impacts uncertainty quantification performance.

Rationale behind each prompt:
1. CoQA, TriviaQA - a simple instruction "Answer the following question as briefly as possible" performs well. Modern LLMs produce answers in the consistent format. This prompt also better reflects real-world question formats.
2. MMLU, GSM8k - use more detailed instructions with a strict, but not overly strict format. Similar to the prompt structure used in Llama 3.1 Instruct evals: https://huggingface.co/datasets/meta-llama/Llama-3.1-8B-Instruct-evals 
3. TruthfulQA - I tested dozens of prompts using the few-shot examples from the original paper. This version yields the best AlignScore performance. The key change: removing the example answer "I have no comment" from the few shot prompt and explicitly instructing the model to abstain when the question is nonsensical. Without this, models tend to reply with "I have no comment" in 30–50% of cases.
4. SamSum - the prompt is adapted from the annotator instructions in the original paper: https://aclanthology.org/D19-5409.pdf
5. XSum - the base prompt + "of no more than 60 words". This addition is crucial to avoid overly long generations, which often degrade in quality compared to shorter summaries (there’s a strong bias toward shorter outputs being better for instruction-tuned LLMs). 
6. WMT - shorter instructions result in format errors, longer - again very strict and lead to overconfidence.

