### PR TITLE
Parametrize similarity

### DIFF
--- a/examples/configs/estimators/default_estimators.yaml
+++ b/examples/configs/estimators/default_estimators.yaml
@@ -64,26 +64,26 @@
 - name: EigenScore
 - name: RenyiNeg
 - name: FisherRao
-- name: MahalanobisDistanceSeq
-- name: RelativeMahalanobisDistanceSeq
-- name: RDESeq
-- name: PPLMDSeq
-  cfg:
-    md_type: "MD"
-- name: PPLMDSeq
-  cfg:
-    md_type: "RMD"
-- name: Focus
-  cfg:
-    model_name: '${model.path}'
-    path: "${cache_path}/focus/${model.path}/token_idf.pkl"
-    gamma: 0.9
-    p: 0.01
-    idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
-    trust_remote_code: True
-    idf_seed: 42
-    idf_dataset_size: -1
-    spacy_path: "en_core_web_sm"
+#- name: MahalanobisDistanceSeq
+#- name: RelativeMahalanobisDistanceSeq
+#- name: RDESeq
+#- name: PPLMDSeq
+#  cfg:
+#    md_type: "MD"
+#- name: PPLMDSeq
+#  cfg:
+#    md_type: "RMD"
+#- name: Focus
+#  cfg:
+#    model_name: '${model.path}'
+#    path: "${cache_path}/focus/${model.path}/token_idf.pkl"
+#    gamma: 0.9
+#    p: 0.01
+#    idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
+#    trust_remote_code: True
+#    idf_seed: 42
+#    idf_dataset_size: -1
+#    spacy_path: "en_core_web_sm"
 - name: AttentionScore
   cfg:
     gen_only: False

--- a/examples/configs/estimators/default_estimators.yaml
+++ b/examples/configs/estimators/default_estimators.yaml
@@ -64,26 +64,26 @@
 - name: EigenScore
 - name: RenyiNeg
 - name: FisherRao
-#- name: MahalanobisDistanceSeq
-#- name: RelativeMahalanobisDistanceSeq
-#- name: RDESeq
-#- name: PPLMDSeq
-#  cfg:
-#    md_type: "MD"
-#- name: PPLMDSeq
-#  cfg:
-#    md_type: "RMD"
-#- name: Focus
-#  cfg:
-#    model_name: '${model.path}'
-#    path: "${cache_path}/focus/${model.path}/token_idf.pkl"
-#    gamma: 0.9
-#    p: 0.01
-#    idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
-#    trust_remote_code: True
-#    idf_seed: 42
-#    idf_dataset_size: -1
-#    spacy_path: "en_core_web_sm"
+- name: MahalanobisDistanceSeq
+- name: RelativeMahalanobisDistanceSeq
+- name: RDESeq
+- name: PPLMDSeq
+  cfg:
+    md_type: "MD"
+- name: PPLMDSeq
+  cfg:
+    md_type: "RMD"
+- name: Focus
+  cfg:
+    model_name: '${model.path}'
+    path: "${cache_path}/focus/${model.path}/token_idf.pkl"
+    gamma: 0.9
+    p: 0.01
+    idf_dataset: "togethercomputer/RedPajama-Data-1T-Sample"
+    trust_remote_code: True
+    idf_seed: 42
+    idf_dataset_size: -1
+    spacy_path: "en_core_web_sm"
 - name: AttentionScore
   cfg:
     gen_only: False

--- a/examples/configs/polygraph_eval_aeslc.yaml
+++ b/examples/configs/polygraph_eval_aeslc.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output
@@ -38,4 +39,3 @@ generation_metrics: null
 ignore_exceptions: false
 seed:
     - 1
-

--- a/examples/configs/polygraph_eval_babiqa.yaml
+++ b/examples/configs/polygraph_eval_babiqa.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_coqa.yaml
+++ b/examples/configs/polygraph_eval_coqa.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - base_processing_coqa
   - _self_
 

--- a/examples/configs/polygraph_eval_coqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_coqa_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - base_processing_coqa
   - _self_
 

--- a/examples/configs/polygraph_eval_gsm8k.yaml
+++ b/examples/configs/polygraph_eval_gsm8k.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_gsm8k_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_gsm8k_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_mmlu.yaml
+++ b/examples/configs/polygraph_eval_mmlu.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_mmlu_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_mmlu_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_person_bio_ar.yaml
+++ b/examples/configs/polygraph_eval_person_bio_ar.yaml
@@ -5,6 +5,7 @@ hydra:
 defaults:
   - model: bloomz-560m
   - estimators: default_claim_estimators
+  - similarity_model: default_multilingual
   - _self_
   
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_person_bio_en_jais.yaml
+++ b/examples/configs/polygraph_eval_person_bio_en_jais.yaml
@@ -5,6 +5,7 @@ hydra:
 defaults:
   - model: bloomz-560m
   - estimators: default_claim_estimators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_person_bio_en_mistral.yaml
+++ b/examples/configs/polygraph_eval_person_bio_en_mistral.yaml
@@ -5,6 +5,7 @@ hydra:
 defaults:
   - model: bloomz-560m
   - estimators: default_claim_estimators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_person_bio_ru.yaml
+++ b/examples/configs/polygraph_eval_person_bio_ru.yaml
@@ -5,6 +5,7 @@ hydra:
 defaults:
   - model: bloomz-560m
   - estimators: default_claim_estimators
+  - similarity_model: default_multilingual
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_person_bio_zh.yaml
+++ b/examples/configs/polygraph_eval_person_bio_zh.yaml
@@ -5,6 +5,7 @@ hydra:
 defaults:
   - model: bloomz-560m
   - estimators: default_claim_estimators
+  - similarity_model: default_multilingual
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_samsum.yaml
+++ b/examples/configs/polygraph_eval_samsum.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_samsum_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_samsum_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_triviaqa.yaml
+++ b/examples/configs/polygraph_eval_triviaqa.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - base_processing_triviaqa
   - _self_
 

--- a/examples/configs/polygraph_eval_triviaqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_triviaqa_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - base_processing_triviaqa
   - _self_
 

--- a/examples/configs/polygraph_eval_truthfulqa.yaml
+++ b/examples/configs/polygraph_eval_truthfulqa.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_truthfulqa_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_truthfulqa_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt14_deen.yaml
+++ b/examples/configs/polygraph_eval_wmt14_deen.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt14_fren.yaml
+++ b/examples/configs/polygraph_eval_wmt14_fren.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt14_fren_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt14_fren_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt19_deen.yaml
+++ b/examples/configs/polygraph_eval_wmt19_deen.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt19_deen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt19_deen_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt19_ruen.yaml
+++ b/examples/configs/polygraph_eval_wmt19_ruen.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_wmt19_ruen_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_wmt19_ruen_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_xsum.yaml
+++ b/examples/configs/polygraph_eval_xsum.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/polygraph_eval_xsum_simple_instruct.yaml
+++ b/examples/configs/polygraph_eval_xsum_simple_instruct.yaml
@@ -6,6 +6,7 @@ defaults:
   - model: bloomz-560m
   - estimators: default_estimators
   - stat_calculators: default_calculators
+  - similarity_model: default_en
   - _self_
 
 cache_path: ./workdir/output

--- a/examples/configs/similarity_model/default_en.yaml
+++ b/examples/configs/similarity_model/default_en.yaml
@@ -1,0 +1,7 @@
+nli:
+  deberta_path: microsoft/deberta-large-mnli
+  batch_size: 10
+cross_encoder:
+  cross_encoder_name: cross-encoder/stsb-roberta-large
+  batch_size: 10
+

--- a/examples/configs/similarity_model/default_multilingual.yaml
+++ b/examples/configs/similarity_model/default_multilingual.yaml
@@ -1,0 +1,7 @@
+nli:
+  deberta_path: MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7
+  batch_size: 10
+cross_encoder:
+  cross_encoder_name: cross-encoder/stsb-roberta-large
+  batch_size: 10
+

--- a/scripts/polygraph_eval
+++ b/scripts/polygraph_eval
@@ -176,22 +176,32 @@ def get_stat_calculator_names(config):
     language = getattr(config, "language", "en")
     output_attentions = getattr(config, "output_attentions", True) and (getattr(config.model, "type", "Whitebox") != "vLLMCausalLM")
     output_hidden_states = False if getattr(config.model, "type", "Whitebox") == "vLLMCausalLM" else True
-    hf_cache = getattr(config, "hf_cache", None)
-    deberta_batch_size = getattr(config, "deberta_batch_size", 10)
     blackbox_supports_logprobs = model_type == "Blackbox" and getattr(
         config.model, "supports_logprobs", False
     )
+
+    sim_cfg = getattr(config, "similarity_model", {})
+
+    nli_cfg = getattr(sim_cfg, "nli", {})
+    nli_deberta_path = nli_cfg.get("deberta_path", None)
+    nli_batch_size = nli_cfg.get("batch_size", None)
+
+    cross_encoder_cfg = getattr(sim_cfg, "cross_encoder", {})
+    cross_encoder_name = cross_encoder_cfg.get("cross_encoder_name", None)
+    cross_encoder_batch_size = cross_encoder_cfg.get("batch_size", None)
 
     all_stat_calculators = []
     if "auto" in config.stat_calculators:
         all_stat_calculators += register_default_stat_calculators(
             model_type,
             language,
-            hf_cache,
             output_attentions=output_attentions, 
             output_hidden_states=output_hidden_states,
             blackbox_supports_logprobs=blackbox_supports_logprobs,
-            deberta_batch_size=deberta_batch_size,
+            nli_deberta_path=nli_deberta_path,
+            nli_batch_size=nli_batch_size,
+            cross_encoder_name=cross_encoder_name,
+            cross_encoder_batch_size=cross_encoder_batch_size,
         )
 
     for stat_calculator in config.stat_calculators:
@@ -306,7 +316,6 @@ def get_model(args):
         return get_vllm_model(args)
     else:
         cache_kwargs = {
-            "cache_dir": getattr(args, "hf_cache", None),
             "token": getattr(args, "hf_token", None),
         }
         return get_whitebox_model(args, cache_kwargs)

--- a/src/lm_polygraph/defaults/register_default_stat_calculators.py
+++ b/src/lm_polygraph/defaults/register_default_stat_calculators.py
@@ -11,11 +11,14 @@ from lm_polygraph.utils.factory_stat_calculator import (
 def register_default_stat_calculators(
     model_type: str,
     language: str = "en",
-    hf_cache: Optional[str] = None,
     blackbox_supports_logprobs: bool = False,
     output_attentions: bool = True,
     output_hidden_states: bool = True,
-    deberta_batch_size: int = 10,
+    *,
+    nli_deberta_path: Optional[str] = None,
+    nli_batch_size: Optional[int] = None,
+    cross_encoder_name: Optional[str] = None,
+    cross_encoder_batch_size: Optional[int] = None,
 ) -> List[StatCalculatorContainer]:
     """
     Specifies the list of the default stat_calculators that could be used in the evaluation scripts and
@@ -43,16 +46,10 @@ def register_default_stat_calculators(
         )
         all_stat_calculators.append(sc)
 
-    if language == "en":
-        deberta_model_path = "microsoft/deberta-large-mnli"
-    else:
-        deberta_model_path = "MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7"
-
     # Shared NLI model config
     nli_model_cfg = {
-        "deberta_path": deberta_model_path,
-        "hf_cache": hf_cache,
-        "batch_size": deberta_batch_size,
+        "deberta_path": nli_deberta_path,
+        "batch_size": nli_batch_size,
         "device": None,
     }
 
@@ -111,16 +108,16 @@ def register_default_stat_calculators(
             CrossEncoderSimilarityMatrixCalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_CrossEncoderSimilarityMatrixCalculator",
             {
-                "batch_size": deberta_batch_size,
-                "cross_encoder_name": "cross-encoder/stsb-roberta-large",
+                "batch_size": cross_encoder_batch_size,
+                "cross_encoder_name": cross_encoder_name,
             },
         )
         _register(
             GreedyCrossEncoderSimilarityMatrixCalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_GreedyCrossEncoderSimilarityMatrixCalculator",
             {
-                "batch_size": 10,
-                "cross_encoder_name": "cross-encoder/stsb-roberta-large",
+                "batch_size": cross_encoder_batch_size,
+                "cross_encoder_name": cross_encoder_name,
             },
         )
         _register(
@@ -170,8 +167,8 @@ def register_default_stat_calculators(
             CrossEncoderSimilarityMatrixVisualCalculator,
             "lm_polygraph.defaults.stat_calculator_builders.default_CrossEncoderSimilarityMatrixVisualCalculator",
             {
-                "batch_size": deberta_batch_size,
-                "cross_encoder_name": "cross-encoder/stsb-roberta-large",
+                "batch_size": cross_encoder_batch_size,
+                "cross_encoder_name": cross_encoder_name,
             },
         )
         _register(

--- a/src/lm_polygraph/defaults/stat_calculator_builders/utils.py
+++ b/src/lm_polygraph/defaults/stat_calculator_builders/utils.py
@@ -9,14 +9,11 @@ def load_nli_model(
     deberta_path="microsoft/deberta-large-mnli",
     batch_size=10,
     device=None,
-    hf_cache: str = None,
 ):
     if deberta_path.startswith("microsoft"):
-        nli_model = Deberta(deberta_path, batch_size, device=device, hf_cache=hf_cache)
+        nli_model = Deberta(deberta_path, batch_size, device=device)
     else:
-        nli_model = MultilingualDeberta(
-            deberta_path, batch_size, device=device, hf_cache=hf_cache
-        )
+        nli_model = MultilingualDeberta(deberta_path, batch_size, device=device)
     log.info(
         f"Initialized {nli_model.deberta_path} on {nli_model.device} with batch_size={nli_model.batch_size}"
     )


### PR DESCRIPTION
- Adds new config group `similarity_model` which contains parameters for NLI and CrossEncoder models.
- Moves default values for batch size and models paths to a new config group
- References new configs in all existing configs
- Allows support for V2 and V3 deberta models
- Removes unused `hf_cache` parameter (can be regulated globally with HF_HOME)