### PR TITLE
Fix sampling params mutation and use max_new_tokens if specified

### DIFF
--- a/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
+++ b/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
@@ -4,7 +4,7 @@ from transformers.generation import GenerateDecoderOnlyOutput
 
 import torch
 from typing import List
-
+from copy import copy
 
 class WhiteboxModelvLLM(Model):
     """Basic whitebox model adapter for using vLLM in stat calculators and uncertainty estimators."""
@@ -46,8 +46,10 @@ class WhiteboxModelvLLM(Model):
         self.model_type = "vLLMCausalLM"
 
     def generate(self, *args, **kwargs):
-        sampling_params = self.sampling_params
+        sampling_params = copy(self.sampling_params)
         sampling_params.n = kwargs.get("num_return_sequences", 1)
+        if "max_new_tokens" in kwargs:
+            sampling_params.max_tokens = kwargs["max_new_tokens"]
         texts = self.tokenizer.batch_decode(
             kwargs["input_ids"], skip_special_tokens=True
         )


### PR DESCRIPTION
vLLM uses `max_tokens` instead of `max_new_tokens`. Previously, when `model.generate()` was called with a `max_new_tokens` parameter, the adapter ignored it and used the value from initialization instead.

For example, P(True) calls `model.generate(max_new_tokens=1)`, but the old code still generated multiple tokens based on the initial `max_tokens` setting.

This PR maps `max_new_tokens` to vLLM's `max_tokens`. Also using `copy()` instead of direct assignment to prevent overwriting the original sampling parameters.