### PR TITLE
Fix: support multimodal model configs for attention-based estimators

### DIFF
--- a/dataset_builders/validate_datasets.py
+++ b/dataset_builders/validate_datasets.py
@@ -5,7 +5,6 @@ from typing import Dict, Tuple, List
 
 import datasets
 
-
 # Mapping from dataset key to (dataset_repo_name, subset)
 DATASET_MAP: Dict[str, Tuple[str, str]] = {
     # base

--- a/src/lm_polygraph/estimators/attention_score.py
+++ b/src/lm_polygraph/estimators/attention_score.py
@@ -58,7 +58,9 @@ class AttentionScore(Estimator):
 
     def __call__(self, stats: Dict[str, np.ndarray]) -> np.ndarray:
         if self.layer is None:
-            _cfg = getattr(stats["model"].model.config, "text_config", stats["model"].model.config)
+            _cfg = getattr(
+                stats["model"].model.config, "text_config", stats["model"].model.config
+            )
             self.layer = _cfg.num_hidden_layers // 2
 
         forwardpass_attention_weights_original = stats["forwardpass_attention_weights"]

--- a/src/lm_polygraph/estimators/rauq.py
+++ b/src/lm_polygraph/estimators/rauq.py
@@ -107,13 +107,17 @@ class RAUQ(Estimator):
             np.ndarray: Uncertainty scores for each sequence
         """
         if self.n_layers is None:
-            _cfg = getattr(stats["model"].model.config, "text_config", stats["model"].model.config)
+            _cfg = getattr(
+                stats["model"].model.config, "text_config", stats["model"].model.config
+            )
             self.n_layers = _cfg.num_hidden_layers
             self.layers = list(
                 range(self.n_layers // 3, int(np.ceil(self.n_layers / 3 * 2) + 1))
             )
         if self.n_heads is None:
-            _cfg = getattr(stats["model"].model.config, "text_config", stats["model"].model.config)
+            _cfg = getattr(
+                stats["model"].model.config, "text_config", stats["model"].model.config
+            )
             self.n_heads = _cfg.num_attention_heads
 
         # Extract diagonal attention patterns for each sequence

--- a/src/lm_polygraph/stat_calculators/attention_forward_pass_visual.py
+++ b/src/lm_polygraph/stat_calculators/attention_forward_pass_visual.py
@@ -60,7 +60,11 @@ class AttentionForwardPassCalculatorVisual(StatCalculator):
 
                             # Get model config for proper dimensions
                             try:
-                                _cfg = getattr(model.model.config, "text_config", model.model.config)
+                                _cfg = getattr(
+                                    model.model.config,
+                                    "text_config",
+                                    model.model.config,
+                                )
                                 num_heads = _cfg.num_attention_heads
                             except Exception:  # Fixed: removed unused 'e'
                                 num_heads = 12  # fallback
@@ -85,7 +89,9 @@ class AttentionForwardPassCalculatorVisual(StatCalculator):
                         # Fallback if no attentions
                         batch_size, seq_len = encoding["input_ids"].shape
                         try:
-                            _cfg = getattr(model.model.config, "text_config", model.model.config)
+                            _cfg = getattr(
+                                model.model.config, "text_config", model.model.config
+                            )
                             num_layers = _cfg.num_hidden_layers
                             num_heads = _cfg.num_attention_heads
                         except Exception:  # Fixed: removed unused 'e'
@@ -98,7 +104,9 @@ class AttentionForwardPassCalculatorVisual(StatCalculator):
                     # Fallback if model didn't return attentions
                     batch_size, seq_len = encoding["input_ids"].shape
                     try:
-                        _cfg = getattr(model.model.config, "text_config", model.model.config)
+                        _cfg = getattr(
+                            model.model.config, "text_config", model.model.config
+                        )
                         num_layers = _cfg.num_hidden_layers
                         num_heads = _cfg.num_attention_heads
                     except Exception:  # Fixed: removed unused 'e'

--- a/src/lm_polygraph/stat_calculators/greedy_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_probs.py
@@ -199,8 +199,7 @@ class GreedyProbsCalculator(StatCalculator):
                 _cfg = getattr(model.model.config, "text_config", model.model.config)
                 attn_mask = np.zeros(
                     shape=(
-                        _cfg.num_attention_heads
-                        * _cfg.num_hidden_layers,
+                        _cfg.num_attention_heads * _cfg.num_hidden_layers,
                         c,
                         c,
                     )

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -258,7 +258,12 @@ class SamplingGenerationCalculator(StatCalculator):
                     batch,
                     model.model_type,
                     level="token",
-                    hidden_layer=int(getattr(model.model.config, "text_config", model.model.config).num_hidden_layers // 2),
+                    hidden_layer=int(
+                        getattr(
+                            model.model.config, "text_config", model.model.config
+                        ).num_hidden_layers
+                        // 2
+                    ),
                 )
 
                 if cur_token_embeddings.dtype == torch.bfloat16:

--- a/src/lm_polygraph/utils/openai_chat.py
+++ b/src/lm_polygraph/utils/openai_chat.py
@@ -4,7 +4,6 @@ import time
 import logging
 import diskcache as dc
 
-
 log = logging.getLogger()
 
 

--- a/test/local/fixtures/generate_fixtures.py
+++ b/test/local/fixtures/generate_fixtures.py
@@ -26,13 +26,15 @@ result = {}
 
 
 def run_eval(dataset):
-    command = f"HYDRA_CONFIG={pwd()}/../../../examples/configs/polygraph_eval_{dataset}.yaml \
+    command = (
+        f"HYDRA_CONFIG={pwd()}/../../../examples/configs/polygraph_eval_{dataset}.yaml \
                 polygraph_eval \
                 subsample_eval_dataset=2 \
                 model.path=bigscience/bloomz-560m \
                 model.load_model_args.device_map={get_device()} \
                 save_path={pwd()} \
                 use_density_based_ue=false"
+    )
 
     return subprocess.run(command, shell=True)
 
@@ -124,12 +126,14 @@ datasets = [
 
 
 def run_claim_eval(dataset):
-    command = f"HYDRA_CONFIG={pwd()}/../../../examples/configs/polygraph_eval_{dataset}.yaml \
+    command = (
+        f"HYDRA_CONFIG={pwd()}/../../../examples/configs/polygraph_eval_{dataset}.yaml \
                 polygraph_eval \
                 subsample_eval_dataset=2 \
                 model.path=bigscience/bloomz-560m \
                 model.load_model_args.device_map={get_device()} \
                 save_path={pwd()}"
+    )
 
     return subprocess.run(command, shell=True)
 

--- a/test/local/test_benchmark.py
+++ b/test/local/test_benchmark.py
@@ -14,7 +14,6 @@ from lm_polygraph.defaults.register_default_stat_calculators import (
     register_default_stat_calculators,
 )
 
-
 # ================= TEST HELPERS ==================
 
 
@@ -67,7 +66,8 @@ def check_result(dataset, exec_result, reference, method=None):
 
 
 def run_eval(dataset):
-    command = f"HYDRA_CONFIG={pwd()}/../../examples/configs/polygraph_eval_{dataset}.yaml \
+    command = (
+        f"HYDRA_CONFIG={pwd()}/../../examples/configs/polygraph_eval_{dataset}.yaml \
                 polygraph_eval \
                 subsample_eval_dataset=4 \
                 model.path=bigscience/bloomz-560m \
@@ -75,6 +75,7 @@ def run_eval(dataset):
                 save_path={pwd()} \
                 stat_calculators.1.cfg.size=10 \
                 stat_calculators.1.cfg.bg_size=20"
+    )
 
     return subprocess.run(command, shell=True)
 
@@ -168,12 +169,14 @@ def run_claim_eval(dataset):
         for k in fixed_cache:
             cache[k] = fixed_cache[k]
 
-    command = f"HYDRA_CONFIG={pwd()}/../../examples/configs/polygraph_eval_{dataset}.yaml \
+    command = (
+        f"HYDRA_CONFIG={pwd()}/../../examples/configs/polygraph_eval_{dataset}.yaml \
                 polygraph_eval \
                 subsample_eval_dataset=2 \
                 model.path=bigscience/bloomz-560m \
                 model.load_model_args.device_map={get_device()} \
                 save_path={pwd()}"
+    )
 
     return subprocess.run(command, shell=True)
 


### PR DESCRIPTION
## Summary

- Multimodal models like **Gemma-3** nest text model parameters (e.g. `num_attention_heads`, `num_hidden_layers`) under `text_config` instead of the top-level config object.
- This causes `AttributeError: 'Gemma3Config' object has no attribute 'num_attention_heads'` when running attention-based uncertainty estimators.
- Uses `getattr(config, "text_config", config)` fallback to resolve these attributes from the correct config level, supporting both standard and multimodal models.

## Files changed

- `stat_calculators/greedy_probs.py`
- `stat_calculators/sample.py`
- `stat_calculators/attention_forward_pass_visual.py`
- `estimators/attention_score.py`
- `estimators/rauq.py`

## Reproduction

```python
from transformers import AutoConfig

# Standard model - attributes at top level
config = AutoConfig.from_pretrained("meta-llama/Meta-Llama-3.1-8B-Instruct")
print(config.num_attention_heads)  # works

# Multimodal model - attributes nested under text_config
config = AutoConfig.from_pretrained("google/gemma-3-12b-it")
print(config.num_attention_heads)  # AttributeError
print(config.text_config.num_attention_heads)  # works
```

## Test plan

- [x] Verified fix works with Gemma-3-12B-IT (multimodal)
- [x] Verified fix works with standard models (Phi-4, LLaMA-3.1, Qwen-3, etc.)