### PR TITLE
Disable thinking mode in vLLM instruct chat

### DIFF
--- a/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
+++ b/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
@@ -68,7 +68,12 @@ class WhiteboxModelvLLM(Model):
                     },
                 ]
                 chats.append(chat)
-            output = self.model.chat(*args, chats, sampling_params)
+            output = self.model.chat(
+                *args,
+                chats,
+                sampling_params,
+                chat_template_kwargs={"enable_thinking": False},
+            )
         else:
             output = self.model.generate(*args, texts, sampling_params)
         return self.post_processing(output)


### PR DESCRIPTION
## Problem

  Qwen3 enables thinking mode by default in its chat template, generating `<think>` blocks before the actual response.
  This interferes with uncertainty estimation, as the generated text contains reasoning traces instead of direct
  answers.

  When using `WhiteboxModelvLLM` with `instruct=True`, the `model.chat()` call invokes `apply_chat_template` internally,
   which enables thinking mode by default for Qwen3.

  ## Fix

  Pass `chat_template_kwargs={"enable_thinking": False}` to `model.chat()`, which propagates to `apply_chat_template`
  and disables thinking mode:

  ```python
  output = self.model.chat(
      *args, chats, sampling_params,
      chat_template_kwargs={"enable_thinking": False},
  )
```
  This uses vLLM's native chat_template_kwargs parameter rather than manually calling apply_chat_template +
  model.generate(), keeping the implementation consistent with vLLM's API.

  ## Affected models

  Models that enable thinking mode by default in their chat template, such as Qwen3.
