### PR TITLE
fix(estimators): negate RenyiNeg and FisherRao to match uncertainty orientation

### DIFF
--- a/src/lm_polygraph/estimators/fisher_rao.py
+++ b/src/lm_polygraph/estimators/fisher_rao.py
@@ -32,7 +32,7 @@ class FisherRao(Estimator):
             stats (Dict[str, np.ndarray]): input statistics, which for multiple samples includes:
                 * logarithms of autoregressive probability distributions at each token in 'greedy_log_probs',
         Returns:
-            np.ndarray: float Fisher-Rao distance for each sample in input statistics.
+            np.ndarray: float negative mean token-level Fisher-Rao distance for each sample in input statistics.
                 Higher values indicate more uncertain samples.
         """
 
@@ -51,4 +51,5 @@ class FisherRao(Estimator):
             )
             scores.append(per_step_scores.mean(-1))
 
-        return np.array(scores)
+        # Distance to uniform decreases when p_t is peaked; negate for UE convention.
+        return -np.array(scores)

--- a/src/lm_polygraph/estimators/renyi_neg.py
+++ b/src/lm_polygraph/estimators/renyi_neg.py
@@ -35,7 +35,7 @@ class RenyiNeg(Estimator):
             stats (Dict[str, np.ndarray]): input statistics, which for multiple samples includes:
                 * logarithms of autoregressive probability distributions at each token in 'greedy_log_probs',
         Returns:
-            np.ndarray: float Rényi divergence for each sample in input statistics.
+            np.ndarray: float negative mean token-level Rényi divergence for each sample in input statistics.
                 Higher values indicate more uncertain samples.
         """
 
@@ -59,4 +59,5 @@ class RenyiNeg(Estimator):
                 per_step_scores *= 1 / (self.alpha - 1)
             scores.append(per_step_scores.mean(-1))
 
-        return np.array(scores)
+        # Divergence to uniform increases when p_t is peaked; negate for UE convention.
+        return -np.array(scores)


### PR DESCRIPTION
## Summary

`RenyiNeg` and `FisherRao` currently compute a token-level divergence/distance between the predictive distribution $p_t$ and the uniform distribution $u$, then average it over generated tokens.

For `RenyiNeg`:  $$U_{\mathrm{RenyiNeg}}(x)  = \frac{1}{T} \sum_{t=1}^{T} D_\alpha(p_t \Vert u)$$ (missing negative sign)

For `FisherRao`: $$U_{\mathrm{FisherRao}}(x) = \frac{1}{T} \sum_{t=1}^{T} FR(p_t, u)$$ (missing negative sign)

Both quantities increase when $p_t$ becomes more peaked and decrease as $p_t$ approaches the uniform distribution. The returned values therefore appear to behave as certainty/confidence scores rather than uncertainty scores.

From my understanding, most other uncertainty estimators and evaluation protocols in LM-Polygraph seem to follow the convention:  $$\text{higher score} \Rightarrow \text{higher uncertainty}.$$

To keep the score orientation consistent with the rest of the library, I negate the returned values of `RenyiNeg` and `FisherRao`.  The underlying divergence/distance computations are unchanged. Only the returned score orientation is modified. Docstrings are updated accordingly.

## Breaking change [semantic; downstream usage; not functional]

Returned scores change sign.

Existing benchmark results, stored predictions, or downstream analyses using these estimators may therefore need to:
- negate previously computed scores,

## Test plan

- [x] `flake8 src/lm_polygraph/estimators/renyi_neg.py src/lm_polygraph/estimators/fisher_rao.py`
- [x] `pytest --ignore=test/local`