### PR TITLE
Make vLLM instruct thinking mode configurable

### DIFF
--- a/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
+++ b/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
@@ -68,7 +68,12 @@ class WhiteboxModelvLLM(Model):
                     },
                 ]
                 chats.append(chat)
-            output = self.model.chat(*args, chats, sampling_params)
+            output = self.model.chat(
+                *args,
+                chats,
+                sampling_params,
+                chat_template_kwargs={"enable_thinking": False},
+            )
         else:
             output = self.model.generate(*args, texts, sampling_params)
         return self.post_processing(output)

--- a/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
+++ b/src/lm_polygraph/model_adapters/whitebox_model_vllm.py
@@ -17,6 +17,7 @@ class WhiteboxModelvLLM(Model):
         generation_parameters: GenerationParameters = GenerationParameters(),
         device: str = "cuda",
         instruct: bool = False,
+        enable_thinking: bool = False,
     ):
         self.model = model
         self.tokenizer = self.model.get_tokenizer()
@@ -24,6 +25,7 @@ class WhiteboxModelvLLM(Model):
         self.sampling_params = sampling_params
         self.generation_parameters = generation_parameters
         self.instruct = instruct
+        self.enable_thinking = enable_thinking
 
         stop_strings = getattr(self.generation_parameters, "stop_strings", None)
         if stop_strings is None:
@@ -72,7 +74,7 @@ class WhiteboxModelvLLM(Model):
                 *args,
                 chats,
                 sampling_params,
-                chat_template_kwargs={"enable_thinking": False},
+                chat_template_kwargs={"enable_thinking": self.enable_thinking},
             )
         else:
             output = self.model.generate(*args, texts, sampling_params)


### PR DESCRIPTION
## Summary

- preserve the original change from #457 with its commit author intact
- expose `enable_thinking` on `WhiteboxModelvLLM`
- keep thinking disabled by default and forward the configured value through `chat_template_kwargs`

## Attribution

The first commit is cherry-picked from #457 and retains `dmndxld <dmndxld@gmail.com>` as its author. The configurability change is a separate follow-up commit.

Supersedes #457.

## Validation

- Python compilation passed
- isolated smoke checks covered both `enable_thinking=False` and `enable_thinking=True`
- no test files are included in the commits