### PR TITLE
fix(estimators): make RAINPROOF score orientation configurable

### DIFF
--- a/src/lm_polygraph/estimators/fisher_rao.py
+++ b/src/lm_polygraph/estimators/fisher_rao.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Dict
+from typing import Dict, Literal
 
 from .estimator import Estimator
 from scipy.special import softmax
@@ -13,27 +13,45 @@ class FisherRao(Estimator):
     Works only with whitebox models (initialized using lm_polygraph.utils.model.WhiteboxModel).
 
     This method calculates the generation Fisher-Rao distance between probability distribution for each token and uniform distribution.
+    By default, the distance is negated to follow the LM-Polygraph convention that
+    higher scores indicate greater uncertainty. Set ``score_type="rainproof"`` to
+    return the original RAINPROOF anomaly-score orientation, where higher scores
+    indicate a distribution farther from uniform.
     Code adapted from https://github.com/icannos/Todd/blob/master/Todd/itscorers.py
     """
 
-    def __init__(self, verbose: bool = False, temperature: float = 2):
+    def __init__(
+        self,
+        verbose: bool = False,
+        temperature: float = 2,
+        score_type: Literal["rainproof", "uncertainty"] = "uncertainty",
+    ):
+        if score_type not in ("rainproof", "uncertainty"):
+            raise ValueError(
+                "score_type must be either 'rainproof' or 'uncertainty', "
+                f"got {score_type!r}"
+            )
         super().__init__(["greedy_log_probs"], "sequence")
         self.verbose = verbose
         self.temperature = temperature
+        self.score_type = score_type
 
     def __str__(self):
-        return "FisherRao"
+        return f"FisherRao_{self.score_type}"
 
     def __call__(self, stats: Dict[str, np.ndarray]) -> np.ndarray:
         """
-        Estimates the Fisher-Rao distance for each sample in the input statistics.
+        Estimates a Fisher-Rao-based score for each sample in the input statistics.
 
         Parameters:
             stats (Dict[str, np.ndarray]): input statistics, which for multiple samples includes:
                 * logarithms of autoregressive probability distributions at each token in 'greedy_log_probs',
         Returns:
-            np.ndarray: float negative mean token-level Fisher-Rao distance for each sample in input statistics.
-                Higher values indicate more uncertain samples.
+            np.ndarray: mean token-level score for each sample in input statistics.
+                With ``score_type="uncertainty"``, returns the negative Fisher-Rao
+                distance, so higher values indicate more uncertain samples.
+                With ``score_type="rainproof"``, returns the Fisher-Rao distance,
+                so higher values indicate distributions farther from uniform.
         """
 
         batch_logits = stats["greedy_log_probs"]
@@ -51,5 +69,7 @@ class FisherRao(Estimator):
             )
             scores.append(per_step_scores.mean(-1))
 
-        # Distance to uniform decreases when p_t is peaked; negate for UE convention.
-        return -np.array(scores)
+        scores = np.array(scores)
+        if self.score_type == "rainproof":
+            return scores
+        return -scores

--- a/src/lm_polygraph/estimators/fisher_rao.py
+++ b/src/lm_polygraph/estimators/fisher_rao.py
@@ -32,7 +32,7 @@ class FisherRao(Estimator):
             stats (Dict[str, np.ndarray]): input statistics, which for multiple samples includes:
                 * logarithms of autoregressive probability distributions at each token in 'greedy_log_probs',
         Returns:
-            np.ndarray: float Fisher-Rao distance for each sample in input statistics.
+            np.ndarray: float negative mean token-level Fisher-Rao distance for each sample in input statistics.
                 Higher values indicate more uncertain samples.
         """
 
@@ -51,4 +51,5 @@ class FisherRao(Estimator):
             )
             scores.append(per_step_scores.mean(-1))
 
-        return np.array(scores)
+        # Distance to uniform decreases when p_t is peaked; negate for UE convention.
+        return -np.array(scores)

--- a/src/lm_polygraph/estimators/renyi_neg.py
+++ b/src/lm_polygraph/estimators/renyi_neg.py
@@ -35,7 +35,7 @@ class RenyiNeg(Estimator):
             stats (Dict[str, np.ndarray]): input statistics, which for multiple samples includes:
                 * logarithms of autoregressive probability distributions at each token in 'greedy_log_probs',
         Returns:
-            np.ndarray: float Rényi divergence for each sample in input statistics.
+            np.ndarray: float negative mean token-level Rényi divergence for each sample in input statistics.
                 Higher values indicate more uncertain samples.
         """
 
@@ -59,4 +59,5 @@ class RenyiNeg(Estimator):
                 per_step_scores *= 1 / (self.alpha - 1)
             scores.append(per_step_scores.mean(-1))
 
-        return np.array(scores)
+        # Divergence to uniform increases when p_t is peaked; negate for UE convention.
+        return -np.array(scores)

--- a/src/lm_polygraph/estimators/renyi_neg.py
+++ b/src/lm_polygraph/estimators/renyi_neg.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Dict
+from typing import Dict, Literal
 
 from .estimator import Estimator
 from scipy.special import softmax
@@ -13,30 +13,47 @@ class RenyiNeg(Estimator):
     Works only with whitebox models (initialized using lm_polygraph.utils.model.WhiteboxModel).
 
     This method calculates the generation Rényi divergence between probability distribution for each token and uniform distribution.
+    By default, the divergence is negated to follow the LM-Polygraph convention that
+    higher scores indicate greater uncertainty. Set ``score_type="rainproof"`` to
+    return the original RAINPROOF anomaly-score orientation, where higher scores
+    indicate a distribution farther from uniform.
     Code adapted from https://github.com/icannos/Todd/blob/master/Todd/itscorers.py
     """
 
     def __init__(
-        self, verbose: bool = False, alpha: float = 0.5, temperature: float = 2
+        self,
+        verbose: bool = False,
+        alpha: float = 0.5,
+        temperature: float = 2,
+        score_type: Literal["rainproof", "uncertainty"] = "uncertainty",
     ):
+        if score_type not in ("rainproof", "uncertainty"):
+            raise ValueError(
+                "score_type must be either 'rainproof' or 'uncertainty', "
+                f"got {score_type!r}"
+            )
         super().__init__(["greedy_log_probs"], "sequence")
         self.verbose = verbose
         self.alpha = alpha
         self.temperature = temperature
+        self.score_type = score_type
 
     def __str__(self):
-        return "RenyiNeg"
+        return f"RenyiNeg_{self.score_type}"
 
     def __call__(self, stats: Dict[str, np.ndarray]) -> np.ndarray:
         """
-        Estimates the Rényi divergence for each sample in the input statistics.
+        Estimates a Rényi-based score for each sample in the input statistics.
 
         Parameters:
             stats (Dict[str, np.ndarray]): input statistics, which for multiple samples includes:
                 * logarithms of autoregressive probability distributions at each token in 'greedy_log_probs',
         Returns:
-            np.ndarray: float negative mean token-level Rényi divergence for each sample in input statistics.
-                Higher values indicate more uncertain samples.
+            np.ndarray: mean token-level score for each sample in input statistics.
+                With ``score_type="uncertainty"``, returns the negative Rényi
+                divergence, so higher values indicate more uncertain samples.
+                With ``score_type="rainproof"``, returns the Rényi divergence,
+                so higher values indicate distributions farther from uniform.
         """
 
         batch_logits = stats["greedy_log_probs"]
@@ -53,11 +70,13 @@ class RenyiNeg(Estimator):
                 )
             else:
                 per_step_scores = np.log((probabilities**self.alpha).sum(-1))
-                per_step_scores -= (self.alpha - 1) * np.log(
+                per_step_scores += (self.alpha - 1) * np.log(
                     np.ones_like(per_step_scores) * probabilities.shape[-1]
                 )
                 per_step_scores *= 1 / (self.alpha - 1)
             scores.append(per_step_scores.mean(-1))
 
-        # Divergence to uniform increases when p_t is peaked; negate for UE convention.
-        return -np.array(scores)
+        scores = np.array(scores)
+        if self.score_type == "rainproof":
+            return scores
+        return -scores


### PR DESCRIPTION
## Summary
- keep `uncertainty` as the default orientation, where higher scores mean greater uncertainty
- add `score_type="rainproof"` to return the original positive RAINPROOF divergence/distance orientation
- distinguish estimator names by score orientation to avoid mixing cached results
- correct the Rényi divergence normalization against the uniform distribution

## Usage
```python
RenyiNeg(score_type="uncertainty")  # default: higher = more uncertain
RenyiNeg(score_type="rainproof")    # higher = farther from uniform

FisherRao(score_type="uncertainty")
FisherRao(score_type="rainproof")
```

This supersedes #459 while preserving Yedson54 as the author of the original orientation-fix commit.

## Validation
- Black and flake8 pass for the changed files
- numerically checked uniform and peaked distributions for both orientations and Rényi `alpha=0.5` / `alpha=1`